### PR TITLE
Add script for notebook instance metrics

### DIFF
--- a/scripts/publish-instance-metrics/amazon-cloudwatch-agent.json
+++ b/scripts/publish-instance-metrics/amazon-cloudwatch-agent.json
@@ -1,0 +1,43 @@
+{
+  "metrics": {
+    "namespace": "SageMakerNotebookInstances",
+    "metrics_collected": {
+      "cpu": {
+        "measurement": [ "cpu_usage_idle" ],
+        "metrics_collection_interval": 60,
+        "append_dimensions": { "notebook_instance_name": "MyNotebookInstance" },
+        "resources": [ "*" ],
+        "totalcpu": true
+      },
+      "disk": {
+        "measurement": [ "used_percent" ],
+        "metrics_collection_interval": 60,
+        "append_dimensions": { "notebook_instance_name": "MyNotebookInstance" },
+        "resources": [ "*" ]
+      },
+      "diskio": {
+        "measurement": [ "write_bytes","read_bytes", "writes", "reads" ],
+        "metrics_collection_interval": 60,
+        "append_dimensions": { "notebook_instance_name": "MyNotebookInstance" },
+        "resources": [ "*" ]
+      },
+      "mem": {
+        "measurement": [ "mem_used_percent" ],
+        "metrics_collection_interval": 60,
+        "append_dimensions": { "notebook_instance_name": "MyNotebookInstance" }
+      },
+      "net": {
+        "measurement": [ "bytes_sent", "bytes_recv", "packets_sent", "packets_recv" ],
+        "metrics_collection_interval": 60,
+        "append_dimensions": { "notebook_instance_name": "MyNotebookInstance" },
+        "resources": [ "*" ]
+      },
+      "swap": {
+        "measurement": [ "swap_used_percent" ],
+        "metrics_collection_interval": 60,
+        "append_dimensions": { "notebook_instance_name": "MyNotebookInstance" }
+      }
+    }
+  }
+}
+

--- a/scripts/publish-instance-metrics/on-start.sh
+++ b/scripts/publish-instance-metrics/on-start.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+# OVERVIEW
+# This script publishes the system-level metrics from the Notebook instance to Cloudwatch.
+#
+# Note that this script will fail if either condition is not met
+#   1. Ensure the Notebook Instance has internet connectivity to fetch the example config
+#   2. Ensure the Notebook Instance execution role permissions to cloudwatch:PutMetricData to publish the system-level metrics
+#
+# https://aws.amazon.com/cloudwatch/pricing/
+
+# PARAMETERS
+NOTEBOOK_INSTANCE_NAME=$(jq '.ResourceName' \
+                      /opt/ml/metadata/resource-metadata.json --raw-output)
+
+echo "Fetching the CloudWatch agent configuration file."
+wget https://raw.githubusercontent.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples/master/scripts/publish-instance-metrics/amazon-cloudwatch-agent.json
+
+sed -i -- "s/MyNotebookInstance/$NOTEBOOK_INSTANCE_NAME/g" amazon-cloudwatch-agent.json
+
+echo "Starting the CloudWatch agent on the Notebook Instance."
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a \
+    fetch-config -m ec2 -c file://$(pwd)/amazon-cloudwatch-agent.json -s
+
+rm amazon-cloudwatch-agent.json


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**  Notebook Instances do not publish any metrics to CloudWatch unlike other components like Endpoints. This prevents us from observing any metrics and in turn creating alarms on those metrics.

Thus, here we use the Unified CloudWatch Agent to publish the metrics to Cloudwatch

**Testing Done**
(If adding a Lifecycle Configuration, please provide *exact* commands or steps to run on a Notebook Instance to validate)
To test this, update the wget command as below:
   
    wget https://raw.githubusercontent.com/imujjwal96/amazon-sagemaker-notebook-instance-lifecycle-config-samples/metrics/scripts/publish-instance-metrics/amazon-cloudwatch-agent.json

- [x] Notebook Instance created successfully with the Lifecycle Configuration
- [x] Notebook Instance stopped and started successfully
- [x] Documentation in the script around any network access requirements
- [x] Documentation in the script around any IAM permission requirements
- [ ] CLI commands used to validate functionality on the instance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.