### PR TITLE
Update README.md CreateLifecycleConfiguration command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ RESOURCE_NAME="$SCRIPT_NAME-$RANDOM"
 # Add any script specific options such as subnet-id
 aws sagemaker create-notebook-instance-lifecycle-config \
     --notebook-instance-lifecycle-config-name "$RESOURCE_NAME" \
-    --on-start Content=$(cat scripts/$SCRIPT_NAME/on-start.sh || echo ""| base64) \
-    --on-create Content=$(cat scripts/$SCRIPT_NAME/on-create.sh || echo ""| base64)
+    --on-start Content=$((cat scripts/$SCRIPT_NAME/on-start.sh || echo "")| base64) \
+    --on-create Content=$((cat scripts/$SCRIPT_NAME/on-create.sh || echo "")| base64)
 
 aws sagemaker create-notebook-instance \
     --notebook-instance-name "$RESOURCE_NAME" \


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- On BSDs the || should be wrapped in brackets or you get an error:

$ aws sagemaker create-notebook-instance-lifecycle-config     --notebook-instance-lifecycle-config-name "$RESOURCE_NAME"     --on-start Content=$(cat script/$SCRIPT_NAME/on-start.sh || echo ""| base64)
usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help

Unknown options: -e, OVERVIEW, #, This, script, ... EOF, #

- On GNU based releases, like the notebook instance, this command should be:

aws sagemaker create-notebook-instance-lifecycle-config     --notebook-instance-lifecycle-config-name "$RESOURCE_NAME"     --on-start Content=$((cat script/$SCRIPT_NAME/on-start.sh || echo "")|base64 --wrap=0)

**Testing Done**

- [ ] Notebook Instance created successfully with the Lifecycle Configuration
- [ ] Notebook Instance stopped and started successfully
- [ ] Documentation in the script around any network access requirements
- [ ] Documentation in the script around any IAM permission requirements
- [x] CLI commands used to validate functionality on the instance

```
# Provide your commands here
/you/commands/here
```
BSD
aws sagemaker create-notebook-instance-lifecycle-config     --notebook-instance-lifecycle-config-name "$RESOURCE_NAME"     --on-start Content=$((cat script/$SCRIPT_NAME/on-start.sh || echo "")|base64)

GNU
aws sagemaker create-notebook-instance-lifecycle-config     --notebook-instance-lifecycle-config-name "$RESOURCE_NAME"     --on-start Content=$((cat script/$SCRIPT_NAME/on-start.sh || echo "")|base64 --wrap=0)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
