### PR TITLE
 Updated the script for proxy settings 

### DIFF
--- a/scripts/proxy-for-jupyter/on-start.sh
+++ b/scripts/proxy-for-jupyter/on-start.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+ 
+set -e
+
+su - ec2-user -c "mkdir /home/ec2-user/.ipython/ && mkdir /home/ec2-user/.ipython/profile_default/ && mkdir /home/ec2-user/.ipython/profile_default/startup/ && touch /home/ec2-user/.ipython/profile_default/startup/00-startup.py"
+
+echo "export http_proxy='http://proxy.local:3128'" | tee -a /home/ec2-user/.profile >/dev/null
+echo "export https_proxy='http://proxy.local:3128'" | tee -a /home/ec2-user/.profile >/dev/null
+echo "export no_proxy='s3.amazonaws.com,127.0.0.1,localhost'" | tee -a /home/ec2-user/.profile >/dev/null
+
+# Now we change the terminal shell to bash
+echo "c.NotebookApp.terminado_settings={'shell_command': ['/bin/bash']}" | tee -a /home/ec2-user/.jupyter/jupyter_notebook_config.py >/dev/null
+
+echo "import sys,os,os.path" | tee -a /home/ec2-user/.ipython/profile_default/startup/00-startup.py >/dev/null
+echo "os.environ['HTTP_PROXY']="\""http://proxy.local:3128"\""" | tee -a /home/ec2-user/.ipython/profile_default/startup/00-startup.py >/dev/null
+echo "os.environ['HTTPS_PROXY']="\""http://proxy.local:3128"\""" | tee -a /home/ec2-user/.ipython/profile_default/startup/00-startup.py >/dev/null
+echo "os.environ['NO_PROXY']="\""s3.amazonaws.com,127.0.0.1,localhost"\""" | tee -a /home/ec2-user/.ipython/profile_default/startup/00-startup.py >/dev/null
+
+# Next, we reboot the system so the bash shell setting can take effect. This reboot is only required when applying proxy settings to the shell environment as well.
+# If only setting up Jupyter notebook proxy, you can leave this out
+
+reboot

--- a/scripts/proxy-for-jupyter/on-start.sh
+++ b/scripts/proxy-for-jupyter/on-start.sh
@@ -1,8 +1,16 @@
+# This script configures proxy settings for your Jupyter notebooks and the SageMaker notebook instance.
+# This is useful for use cases where you would like to configure your notebook instance in your custom VPC
+# without direct internet access to route all traffic via a proxy server in your VPC.
+
+# Please ensure that you have already configure a proxy server in your VPC.
+
 #!/bin/bash
  
 set -e
 
 su - ec2-user -c "mkdir /home/ec2-user/.ipython/ && mkdir /home/ec2-user/.ipython/profile_default/ && mkdir /home/ec2-user/.ipython/profile_default/startup/ && touch /home/ec2-user/.ipython/profile_default/startup/00-startup.py"
+
+# Please replace proxy.local:3128 with the URL of your proxy server eg, proxy.example.com:80 and proxy.example.com:443
 
 echo "export http_proxy='http://proxy.local:3128'" | tee -a /home/ec2-user/.profile >/dev/null
 echo "export https_proxy='http://proxy.local:3128'" | tee -a /home/ec2-user/.profile >/dev/null

--- a/scripts/proxy-for-jupyter/on-start.sh
+++ b/scripts/proxy-for-jupyter/on-start.sh
@@ -10,18 +10,22 @@ set -e
 
 su - ec2-user -c "mkdir /home/ec2-user/.ipython/ && mkdir /home/ec2-user/.ipython/profile_default/ && mkdir /home/ec2-user/.ipython/profile_default/startup/ && touch /home/ec2-user/.ipython/profile_default/startup/00-startup.py"
 
-# Please replace proxy.local:3128 with the URL of your proxy server eg, proxy.example.com:80 and proxy.example.com:443
+# Please replace proxy.local:3128 with the URL of your proxy server eg, proxy.example.com:80 or proxy.example.com:443
+# Please note that we are excluding S3 because we do not want this traffic to be routed over the public internet, but rather through the S3 endpoint in the VPC.
 
-echo "export http_proxy='http://proxy.local:3128'" | tee -a /home/ec2-user/.profile >/dev/null
-echo "export https_proxy='http://proxy.local:3128'" | tee -a /home/ec2-user/.profile >/dev/null
+#PARAMETER
+SERVER=http://proxy.local:3128
+
+echo "export http_proxy='$SERVER'" | tee -a /home/ec2-user/.profile >/dev/null
+echo "export https_proxy='$SERVER'" | tee -a /home/ec2-user/.profile >/dev/null
 echo "export no_proxy='s3.amazonaws.com,127.0.0.1,localhost'" | tee -a /home/ec2-user/.profile >/dev/null
 
 # Now we change the terminal shell to bash
 echo "c.NotebookApp.terminado_settings={'shell_command': ['/bin/bash']}" | tee -a /home/ec2-user/.jupyter/jupyter_notebook_config.py >/dev/null
 
 echo "import sys,os,os.path" | tee -a /home/ec2-user/.ipython/profile_default/startup/00-startup.py >/dev/null
-echo "os.environ['HTTP_PROXY']="\""http://proxy.local:3128"\""" | tee -a /home/ec2-user/.ipython/profile_default/startup/00-startup.py >/dev/null
-echo "os.environ['HTTPS_PROXY']="\""http://proxy.local:3128"\""" | tee -a /home/ec2-user/.ipython/profile_default/startup/00-startup.py >/dev/null
+echo "os.environ['HTTP_PROXY']="\""$SERVER"\""" | tee -a /home/ec2-user/.ipython/profile_default/startup/00-startup.py >/dev/null
+echo "os.environ['HTTPS_PROXY']="\""$SERVER"\""" | tee -a /home/ec2-user/.ipython/profile_default/startup/00-startup.py >/dev/null
 echo "os.environ['NO_PROXY']="\""s3.amazonaws.com,127.0.0.1,localhost"\""" | tee -a /home/ec2-user/.ipython/profile_default/startup/00-startup.py >/dev/null
 
 # Next, we reboot the system so the bash shell setting can take effect. This reboot is only required when applying proxy settings to the shell environment as well.

--- a/scripts/proxy-for-jupyter/on-start.sh
+++ b/scripts/proxy-for-jupyter/on-start.sh
@@ -8,7 +8,7 @@
  
 set -e
 
-su - ec2-user -c "mkdir /home/ec2-user/.ipython/ && mkdir /home/ec2-user/.ipython/profile_default/ && mkdir /home/ec2-user/.ipython/profile_default/startup/ && touch /home/ec2-user/.ipython/profile_default/startup/00-startup.py"
+su - ec2-user -c "mkdir -p /home/ec2-user/.ipython/profile_default/startup/ && touch /home/ec2-user/.ipython/profile_default/startup/00-startup.py"
 
 # Please replace proxy.local:3128 with the URL of your proxy server eg, proxy.example.com:80 or proxy.example.com:443
 # Please note that we are excluding S3 because we do not want this traffic to be routed over the public internet, but rather through the S3 endpoint in the VPC.


### PR DESCRIPTION
This script enable customer to setup proxy settings for the Jupyter notebooks and the SageMaker notebook instance. In order for the Jupyter notebooks to be able to pick up the proxy settings from the Lifecycle Configuration, we need to specify these settings in the ipython notebook server environment. To configure the ipython notebook server profile, we will create a simple python script 00-startup.py under /home/ec2-user/.ipython/profile_default/startup path (the 00 in the script name is because scripts under this path are run in lexicographical order, and we want this to be run first). 

Additionally, the default terminal shell that is spawned whenever you open a terminal in Jupyter is a non-logging shell, i.e., it is an interactive shell. Therefore, for the proxy settings to be apply to the shell environment as well via the Lifecycle Configuration, we need to change the default interactive shell to a logging shell like bash and put the proxy setting in /home/ec2-user/.profile.

**Issue #, if available:**

**Description of changes:**
Added comment regarding networking requirements

**Testing Done**

- [x] Notebook Instance created successfully with the Lifecycle Configuration
- [x] Notebook Instance stopped and started successfully
- [x] Documentation in the script around any network access requirements
- [ ] Documentation in the script around any IAM permission requirements
- [x] CLI commands used to validate functionality on the instance

```
# Open a terminal window and run the following:
$ wget amazon.com
```
```
# Open a Jupyter notebook and run the following in a cell
import requests
requests.get("http://google.com")
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
