### PR TITLE
Autostop SageMaker notebook when idle

### DIFF
--- a/scripts/auto-stop-idle/autostop.py
+++ b/scripts/auto-stop-idle/autostop.py
@@ -80,7 +80,7 @@ def get_notebook_name():
     log_path = '/opt/ml/metadata/resource-metadata.json'
     with open(log_path, 'r') as logs:
         _logs = json.load(logs)
-    return _logs['ResourceArn']
+    return _logs['ResourceName']
 
 response = requests.get('https://localhost:'+port+'/api/sessions', verify=False)
 data = response.json()

--- a/scripts/auto-stop-idle/autostop.py
+++ b/scripts/auto-stop-idle/autostop.py
@@ -17,7 +17,7 @@ import getopt, sys, re
 import urllib3
 import boto3
 
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+urllib3.disable_warnings(urllib3.excepqqtions.InsecureRequestWarning)
 
 # Usage
 usageInfo = """Usage:

--- a/scripts/auto-stop-idle/autostop.py
+++ b/scripts/auto-stop-idle/autostop.py
@@ -17,7 +17,7 @@ import getopt, sys, re
 import urllib3
 import boto3
 
-urllib3.disable_warnings(urllib3.excepqqtions.InsecureRequestWarning)
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 # Usage
 usageInfo = """Usage:

--- a/scripts/auto-stop-idle/autostop.py
+++ b/scripts/auto-stop-idle/autostop.py
@@ -1,0 +1,110 @@
+#     Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License").
+#     You may not use this file except in compliance with the License.
+#     A copy of the License is located at
+#
+#         https://aws.amazon.com/apache-2-0/
+#
+#     or in the "license" file accompanying this file. This file is distributed
+#     on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+#     express or implied. See the License for the specific language governing
+#     permissions and limitations under the License.
+
+import requests
+from datetime import datetime
+import getopt, sys, re
+import urllib3
+import boto3
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+# Usage
+usageInfo = """Usage:
+This scripts checks if a notebook is idle for X seconds if it does, it'll stop the notebook:
+python autostop.py --time <time_in_seconds> [--port <jupyter_port>] [--ignore-connections]
+Type "python autostop.py -h" for available options.
+"""
+# Help info
+helpInfo = """-t, --time
+    Auto stop time in seconds
+-p, --port
+    jupyter port
+-c --ignore-connections
+    Stop notebook once idle, ignore connected users
+-h, --help
+    Help information
+"""
+
+# Read in command-line parameters
+idle = True
+port = '8443'
+ignore_connections = False
+try:
+    opts, args = getopt.getopt(sys.argv[1:], "ht:p:c", ["help","time=","port=","ignore-connections"])
+    if len(opts) == 0:
+        raise getopt.GetoptError("No input parameters!")
+    for opt, arg in opts:
+        if opt in ("-h", "--help"):
+            print(helpInfo)
+            exit(0)
+        if opt in ("-t", "--time"):
+            time = int(arg)
+        if opt in ("-p", "--port"):
+            port = str(arg)
+        if opt in ("-c", "--ignore-connections"):
+            ignore_connections = True
+except getopt.GetoptError:
+    print(usageInfo)
+    exit(1)
+
+# Missing configuration notification
+missingConfiguration = False
+if not time:
+    print("Missing '-t' or '--time'")
+    missingConfiguration = True
+if missingConfiguration:
+    exit(2)
+
+
+def is_idle(last_activity):
+    last_activity = datetime.strptime(last_activity,"%Y-%m-%dT%H:%M:%S.%fz")
+    if (datetime.now() - last_activity).total_seconds() > time:
+        return True
+    else:
+        return False
+
+
+def get_notebook_name():
+    pattern = 'notebookInstanceArn=(arn:(aws[a-zA-Z-]*)?:sagemaker:[a-z]{2}((-gov)|(-iso(b?)))?-[a-z]+-\d{1}:\d{12}:(notebook-instance\/([a-zA-Z0-9_-]*)))'
+    log_path = '/var/log/nbiagent.log'
+    with open(log_path, 'r') as logs:
+        _logs = logs.read()
+        notebook = re.search(pattern, _logs).group(8)
+    return notebook
+
+response = requests.get('https://localhost:'+port+'/api/sessions', verify=False)
+data = response.json()
+if len(data) > 0:
+    for notebook in data:
+        if notebook['kernel']['execution_state'] == 'idle':
+            if not ignore_connections:
+                if notebook['kernel']['connections'] == 0:
+                    if not is_idle(notebook['kernel']['last_activity']):
+                        idle = False
+                else:
+                    idle = False
+            else:
+                if not is_idle(notebook['kernel']['last_activity']):
+                    idle = False
+        else:
+            idle = False
+else:
+    idle = False
+
+if idle:
+    client = boto3.client('sagemaker')
+    client.stop_notebook_instance(
+        NotebookInstanceName=get_notebook_name()
+    )
+

--- a/scripts/auto-stop-idle/autostop.py
+++ b/scripts/auto-stop-idle/autostop.py
@@ -13,9 +13,10 @@
 
 import requests
 from datetime import datetime
-import getopt, sys, re
+import getopt, sys
 import urllib3
 import boto3
+import json
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -76,12 +77,10 @@ def is_idle(last_activity):
 
 
 def get_notebook_name():
-    pattern = 'notebookInstanceArn=(arn:(aws[a-zA-Z-]*)?:sagemaker:[a-z]{2}((-gov)|(-iso(b?)))?-[a-z]+-\d{1}:\d{12}:(notebook-instance\/([a-zA-Z0-9_-]*)))'
-    log_path = '/var/log/nbiagent.log'
+    log_path = '/opt/ml/metadata/resource-metadata.json'
     with open(log_path, 'r') as logs:
-        _logs = logs.read()
-        notebook = re.search(pattern, _logs).group(8)
-    return notebook
+        _logs = json.load(logs)
+    return _logs['ResourceArn']
 
 response = requests.get('https://localhost:'+port+'/api/sessions', verify=False)
 data = response.json()

--- a/scripts/auto-stop-idle/on-start.sh
+++ b/scripts/auto-stop-idle/on-start.sh
@@ -11,7 +11,6 @@ set -e
 #   1. Ensure the Notebook Instance has internet connectivity to fetch the example config
 #   2. Ensure the Notebook Instance execution role permissions to SageMaker:StopNotebookInstance to stop the notebook
 #
-# https://aws.amazon.com/cloudwatch/pricing/
 
 # PARAMETERS
 IDLE_TIME=3600

--- a/scripts/auto-stop-idle/on-start.sh
+++ b/scripts/auto-stop-idle/on-start.sh
@@ -19,4 +19,4 @@ wget https://raw.githubusercontent.com/fernbach/amazon-sagemaker-notebook-instan
 
 echo "Starting the SageMaker autostop script in cron"
 
-(crontab -l 2>/dev/null; echo "5 * * * * /usr/bin/python autostop.py --time $IDLE_TIME") | crontab -
+(crontab -l 2>/dev/null; echo "5 * * * * /usr/bin/python $PWD/autostop.py --time $IDLE_TIME") | crontab -

--- a/scripts/auto-stop-idle/on-start.sh
+++ b/scripts/auto-stop-idle/on-start.sh
@@ -15,7 +15,7 @@ set -e
 IDLE_TIME=3600
 
 echo "Fetching the autostop script"
-wget https://raw.githubusercontent.com/fernbach/amazon-sagemaker-notebook-instance-lifecycle-config-samples/master/scripts/auto-stop-idle/autostop.py
+wget https://raw.githubusercontent.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples/master/scripts/auto-stop-idle/autostop.py
 
 echo "Starting the SageMaker autostop script in cron"
 

--- a/scripts/auto-stop-idle/on-start.sh
+++ b/scripts/auto-stop-idle/on-start.sh
@@ -5,7 +5,7 @@ set -e
 # OVERVIEW
 # This script stops a SageMaker notebook once it's idle for more then 1 hour (default time)
 # You can change the idle time for stop using the environment variable bellow.
-# If you want the notebook the stop if it's idle and a user is still connected, add the --ignore-connections flag
+# If you want the notebook the stop only if no browsers are open, remove the --ignore-connections flag
 #
 # Note that this script will fail if either condition is not met
 #   1. Ensure the Notebook Instance has internet connectivity to fetch the example config
@@ -20,4 +20,4 @@ wget https://raw.githubusercontent.com/aws-samples/amazon-sagemaker-notebook-ins
 
 echo "Starting the SageMaker autostop script in cron"
 
-(crontab -l 2>/dev/null; echo "5 * * * * /usr/bin/python $PWD/autostop.py --time $IDLE_TIME") | crontab -
+(crontab -l 2>/dev/null; echo "5 * * * * /usr/bin/python $PWD/autostop.py --time $IDLE_TIME --ignore-connections") | crontab -

--- a/scripts/auto-stop-idle/on-start.sh
+++ b/scripts/auto-stop-idle/on-start.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+# OVERVIEW
+# This script publishes the system-level metrics from the Notebook instance to Cloudwatch.
+#
+# Note that this script will fail if either condition is not met
+#   1. Ensure the Notebook Instance has internet connectivity to fetch the example config
+#   2. Ensure the Notebook Instance execution role permissions to cloudwatch:PutMetricData to publish the system-level metrics
+#
+# https://aws.amazon.com/cloudwatch/pricing/
+
+# PARAMETERS
+IDLE_TIME=3600
+
+echo "Fetching the autostop script"
+wget https://raw.githubusercontent.com/fernbach/amazon-sagemaker-notebook-instance-lifecycle-config-samples/master/scripts/auto-stop-idle/autostop.py
+
+echo "Starting the SageMaker autostop script in cron"
+
+(crontab -l 2>/dev/null; echo "5 * * * * /usr/bin/python autostop.py --time $IDLE_TIME") | crontab -

--- a/scripts/auto-stop-idle/on-start.sh
+++ b/scripts/auto-stop-idle/on-start.sh
@@ -3,11 +3,13 @@
 set -e
 
 # OVERVIEW
-# This script publishes the system-level metrics from the Notebook instance to Cloudwatch.
+# This script stops a SageMaker notebook once it's idle for more then 1 hour (default time)
+# You can change the idle time for stop using the environment variable bellow.
+# If you want the notebook the stop if it's idle and a user is still connected, add the --ignore-connections flag
 #
 # Note that this script will fail if either condition is not met
 #   1. Ensure the Notebook Instance has internet connectivity to fetch the example config
-#   2. Ensure the Notebook Instance execution role permissions to cloudwatch:PutMetricData to publish the system-level metrics
+#   2. Ensure the Notebook Instance execution role permissions to SageMaker:StopNotebookInstance to stop the notebook
 #
 # https://aws.amazon.com/cloudwatch/pricing/
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

**Testing Done**

- [x] Notebook Instance created successfully with the Lifecycle Configuration
- [x] Notebook Instance stopped and started successfully
- [x] Documentation in the script around any network access requirements
- [x] Documentation in the script around any IAM permission requirements
- [x] CLI commands used to validate functionality on the instance

```
# Provide your commands here
sh on-start.sh
```





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
