### PR TITLE
Further improve instructions

### DIFF
--- a/scripts/install-conda-package-all-environments/on-start.sh
+++ b/scripts/install-conda-package-all-environments/on-start.sh
@@ -7,8 +7,8 @@ set -e
 # system environment reserved for Jupyter.
 
 # NOTE: if the total runtime of this script exceeds 5 minutes, the Notebook Instance will fail to start up.  If you would
-# like to run this script in the background, then add "nohup" before "sudo" below (e.g. "nohup sudo").  This will allow the
-# notebook instance to start up while the installation happens in the background.
+# like to run this script in the background, then replace "sudo" with "nohup sudo -b".  This will allow the
+# Notebook Instance to start up while the installation happens in the background.
 
 sudo -u ec2-user -i <<'EOF'
 


### PR DESCRIPTION
**Issue #, if available:**
#7 

**Description of changes:**
Further improve the directions as ```sudo -b``` is necessary to truly ensure that the process runs in the background.  nohup, alone, doesn't background the process, you must either submit a job (via "&") or use sudo's built-in support for background processes.

**Testing Done**

- [X] Notebook Instance created successfully with the Lifecycle Configuration
- [X] Notebook Instance stopped and started successfully
- [N/A] Documentation in the script around any network access requirements
- [N/A] Documentation in the script around any IAM permission requirements
- [N/A] CLI commands used to validate functionality on the instance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
