### PR TITLE
Add script for setting env variable and configuring Git

### DIFF
--- a/scripts/set-env-variable/on-start.sh
+++ b/scripts/set-env-variable/on-start.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# OVERVIEW
+# This script gets value from Notebook Instance's tag and sets it as environment
+# variable for all process including Jupyter in SageMaker Notebook Instance
+
+# PARAMETERS
+YOUR_ENV_VARIABLE_NAME=your_env_variable_name
+
+NOTEBOOK_ARN=$(jq '.ResourceArn' /opt/ml/metadata/resource-metadata.json --raw-output)
+TAG=$(aws sagemaker list-tags --resource-arn $NOTEBOOK_ARN  | jq .'Tags[] | select(.Key == "$YOUR_ENV_VARIABLE_NAME").Value' --raw-output)
+touch /etc/profile.d/jupyter-env.sh
+echo "export YOUR_ENV_VARIABLE_NAME=$TAG" >> /etc/profile.d/jupyter-env.sh
+initctl restart jupyter-server --no-wait

--- a/scripts/set-env-variable/on-start.sh
+++ b/scripts/set-env-variable/on-start.sh
@@ -5,6 +5,9 @@ set -e
 # OVERVIEW
 # This script gets value from Notebook Instance's tag and sets it as environment
 # variable for all process including Jupyter in SageMaker Notebook Instance
+# Note that this script will fail this condition is not met
+#   1. Ensure the Notebook Instance execution role has permission of SageMaker:ListTags
+#
 
 # PARAMETERS
 YOUR_ENV_VARIABLE_NAME=your_env_variable_name

--- a/scripts/set-env-variable/on-start.sh
+++ b/scripts/set-env-variable/on-start.sh
@@ -15,5 +15,5 @@ YOUR_ENV_VARIABLE_NAME=your_env_variable_name
 NOTEBOOK_ARN=$(jq '.ResourceArn' /opt/ml/metadata/resource-metadata.json --raw-output)
 TAG=$(aws sagemaker list-tags --resource-arn $NOTEBOOK_ARN  | jq .'Tags[] | select(.Key == "$YOUR_ENV_VARIABLE_NAME").Value' --raw-output)
 touch /etc/profile.d/jupyter-env.sh
-echo "export YOUR_ENV_VARIABLE_NAME=$TAG" >> /etc/profile.d/jupyter-env.sh
+echo "export $YOUR_ENV_VARIABLE_NAME=$TAG" >> /etc/profile.d/jupyter-env.sh
 initctl restart jupyter-server --no-wait

--- a/scripts/set-git-config/on-start.sh
+++ b/scripts/set-git-config/on-start.sh
@@ -13,3 +13,5 @@ sudo -u ec2-user -i <<'EOF'
 
 git config --global user.name $YOUR_USER_NAME
 git config --global user.email $YOUR_EMAIL_ADDRESS
+
+EOF

--- a/scripts/set-git-config/on-start.sh
+++ b/scripts/set-git-config/on-start.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# OVERVIEW
+# This script sets username and email address in Git config
+
+# PARAMETERS
+YOUR_USER_NAME=your_user_name
+YOUR_EMAIL_ADDRESS=your_email_address
+
+sudo -u ec2-user -i <<'EOF'
+
+git config --global user.name $YOUR_USER_NAME
+git config --global user.email $YOUR_EMAIL_ADDRESS


### PR DESCRIPTION
**Description**
Add script for setting env variable and configuring Git

**Motivation**
Add a way to set env varible in lifecycle config so it could be used in all Jupyter envs. Add a way to set Git config. For now user is default to ec2-user and email is default to host ip.

**Testing Done**
* Verified that env variable is set
* Verified that username and email are set in Git config

- [x ] Notebook Instance created successfully with the Lifecycle Configuration
- [x ] Notebook Instance stopped and started successfully
- [x] Documentation in the script around any network access requirements
- [x] Documentation in the script around any IAM permission requirements
- [x] CLI commands used to validate functionality on the instance

```
# Provide your commands here
echo $YOUR_ENV_VARIABLE_NAME
git config --list
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
