### PR TITLE
Script to execute notebook file on startup using nbconvert

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Lifecycle Configurations provide a mechanism to customize Notebook Instances via
 
 * [auto-stop-idle](scripts/auto-stop-idle) - This script stops a SageMaker notebook once it's idle for more then 1 hour. (default time)
 * [connect-emr-cluster](scripts/connect-emr-cluster) - This script connects an EMR cluster to the Notebook Instance using SparkMagic.
+* [execute-notebook-on-startup](scripts/execute-notebook-on-startup) - This script executes a Notebook file on the instance during startup.
 * [install-conda-package-all-environments](scripts/install-conda-package-all-environments) - is script installs a single conda package in all SageMaker conda environments, apart from the JupyterSystemEnv which is a system environment reserved for Jupyter.
 * [install-conda-package-single-environment](scripts/install-conda-package-single-environment) - This script installs a single conda package in a single SageMaker conda environments.
 * [install-lab-extension](scripts/install-lab-extension) - This script installs a jupyterlab extension package in SageMaker Notebook Instance.

--- a/scripts/execute-notebook-on-startup/on-start.sh
+++ b/scripts/execute-notebook-on-startup/on-start.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+# OVERVIEW
+# This script executes an existing Notebook file on the instance during start using nbconvert(https://github.com/jupyter/nbconvert)
+
+# PARAMETERS
+
+ENVIRONMENT=pytorch_p36
+NOTEBOOK_FILE=/home/ec2-user/SageMaker/MyNotebook.ipynb
+
+source /home/ec2-user/anaconda3/bin/activate "$ENVIRONMENT"
+
+jupyter nbconvert "$NOTEBOOK_FILE" --ExecutePreprocessor.kernel_name=python --execute
+
+source /home/ec2-user/anaconda3/bin/deactivate


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

**Testing Done**

- [x] Notebook Instance created successfully with the Lifecycle Configuration
- [x] Notebook Instance stopped and started successfully
- [N/A] Documentation in the script around any network access requirements
- [N/A] Documentation in the script around any IAM permission requirements
- [N/A] CLI commands used to validate functionality on the instance

- [x] New script link and description added to README.md

```
# Provide your commands here
Verified that I'm able to see the executed `MyNotebook.ipynb` on the instance.
```





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
