### PR TITLE
bug fix: Fix auto stop for session-less notebooks instances

### DIFF
--- a/scripts/auto-stop-idle/autostop.py
+++ b/scripts/auto-stop-idle/autostop.py
@@ -99,7 +99,12 @@ if len(data) > 0:
         else:
             idle = False
 else:
-    idle = False
+    client = boto3.client('sagemaker')
+    uptime = client.describe_notebook_instance(
+        NotebookInstanceName=get_notebook_name()
+    )['LastModifiedTime']
+    if not is_idle(uptime.strftime("%Y-%m-%dT%H:%M:%S.%fz")):
+        idle = False
 
 if idle:
     client = boto3.client('sagemaker')

--- a/scripts/auto-stop-idle/on-start.sh
+++ b/scripts/auto-stop-idle/on-start.sh
@@ -10,7 +10,7 @@ set -e
 # Note that this script will fail if either condition is not met
 #   1. Ensure the Notebook Instance has internet connectivity to fetch the example config
 #   2. Ensure the Notebook Instance execution role permissions to SageMaker:StopNotebookInstance to stop the notebook 
-#       and SageMaker:StopNotebookInstance to describe the notebook.
+#       and SageMaker:DescribeNotebookInstance to describe the notebook.
 #
 
 # PARAMETERS

--- a/scripts/auto-stop-idle/on-start.sh
+++ b/scripts/auto-stop-idle/on-start.sh
@@ -9,7 +9,8 @@ set -e
 #
 # Note that this script will fail if either condition is not met
 #   1. Ensure the Notebook Instance has internet connectivity to fetch the example config
-#   2. Ensure the Notebook Instance execution role permissions to SageMaker:StopNotebookInstance to stop the notebook
+#   2. Ensure the Notebook Instance execution role permissions to SageMaker:StopNotebookInstance to stop the notebook 
+#       and SageMaker:StopNotebookInstance to describe the notebook.
 #
 
 # PARAMETERS


### PR DESCRIPTION
**Issue #, if available:**
16
**Description of changes:**
This fixes the script behavior to auto-stop the instance if no one has connected to it. 

Essentially if there are no kernels on the notebook server, it checks the LastModifiedTime to determine the last Start/Stop time and checks that against idle timeout.

**Testing Done**

- [x] Notebook Instance created successfully with the Lifecycle Configuration
- [x] Notebook Instance stopped and started successfully
- [x] Documentation in the script around any network access requirements
- [x] Documentation in the script around any IAM permission requirements
- [x] CLI commands used to validate functionality on the instance
- [x] New script link and description added to README.md

```
See scripts/auto-stop-idle/autostop.py for changes.
```





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
