### PR TITLE
Update on-start set-env script with bug fix for setting tag variable

### DIFF
--- a/scripts/set-env-variable/on-start.sh
+++ b/scripts/set-env-variable/on-start.sh
@@ -13,7 +13,7 @@ set -e
 YOUR_ENV_VARIABLE_NAME=your_env_variable_name
 
 NOTEBOOK_ARN=$(jq '.ResourceArn' /opt/ml/metadata/resource-metadata.json --raw-output)
-TAG=$(aws sagemaker list-tags --resource-arn $NOTEBOOK_ARN  | jq .'Tags[] | select(.Key == "$YOUR_ENV_VARIABLE_NAME").Value' --raw-output)
+TAG=$(aws sagemaker list-tags --resource-arn $NOTEBOOK_ARN  | jq -r --arg YOUR_ENV_VARIABLE_NAME "$YOUR_ENV_VARIABLE_NAME" .'Tags[] | select(.Key == $YOUR_ENV_VARIABLE_NAME).Value' --raw-output)
 touch /etc/profile.d/jupyter-env.sh
 echo "export $YOUR_ENV_VARIABLE_NAME=$TAG" >> /etc/profile.d/jupyter-env.sh
 initctl restart jupyter-server --no-wait


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fix to set-env script to properly set "TAG" variable
**Testing Done**

- [x] Notebook Instance created successfully with the Lifecycle Configuration
- [x] Notebook Instance stopped and started successfully
- [ ] Documentation in the script around any network access requirements
- [ ] Documentation in the script around any IAM permission requirements
- [ ] CLI commands used to validate functionality on the instance
- [ ] New script link and description added to README.md

```
# Provide your commands here
/you/commands/here
```





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
