### PR TITLE
Enable scripts to complete properly

### DIFF
--- a/scripts/install-conda-package-all-environments/on-start.sh
+++ b/scripts/install-conda-package-all-environments/on-start.sh
@@ -10,7 +10,7 @@ set -e
 # like to run this script in the background, then replace "sudo" with "nohup sudo -b".  This will allow the
 # Notebook Instance to start up while the installation happens in the background.
 
-sudo -u ec2-user -i <<'EOF'
+sudo -u ec2-user -i <<EOF
 
 # PARAMETERS
 PACKAGE=scipy

--- a/scripts/install-conda-package-single-environment/on-start.sh
+++ b/scripts/install-conda-package-single-environment/on-start.sh
@@ -5,7 +5,7 @@ set -e
 # OVERVIEW
 # This script installs a single conda package in a single SageMaker conda environments.
 
-sudo -u ec2-user -i <<'EOF'
+sudo -u ec2-user -i <<EOF
 
 # PARAMETERS
 PACKAGE=scipy

--- a/scripts/install-lab-extension/on-start.sh
+++ b/scripts/install-lab-extension/on-start.sh
@@ -5,7 +5,7 @@ set -e
 # OVERVIEW
 # This script installs a jupyterlab extension package in SageMaker Notebook Instance
 
-sudo -u ec2-user -i <<'EOF'
+sudo -u ec2-user -i <<EOF
 
 # PARAMETERS
 EXTENSION_NAME=@jupyterlab/git

--- a/scripts/install-nb-extension/on-start.sh
+++ b/scripts/install-nb-extension/on-start.sh
@@ -6,7 +6,7 @@ set -e
 # This script installs a single jupyter notebook extension package in SageMaker Notebook Instance
 # For more details of the example extension, see https://github.com/jupyter-widgets/ipywidgets
 
-sudo -u ec2-user -i <<'EOF'
+sudo -u ec2-user -i <<EOF
 
 # PARAMETERS
 PIP_PACKAGE_NAME=ipywidgets

--- a/scripts/install-pip-package-all-environments/on-start.sh
+++ b/scripts/install-pip-package-all-environments/on-start.sh
@@ -8,7 +8,7 @@ set -e
 # Note this may timeout if the package installations in all environments take longer than 5 mins, consider using "nohup" to run this 
 # as a background process in that case.
 
-sudo -u ec2-user -i <<'EOF'
+sudo -u ec2-user -i <<EOF
 
 # PARAMETERS
 PACKAGE=scipy

--- a/scripts/install-pip-package-single-environment/on-start.sh
+++ b/scripts/install-pip-package-single-environment/on-start.sh
@@ -5,7 +5,7 @@ set -e
 # OVERVIEW
 # This script installs a single pip package in a single SageMaker conda environments.
 
-sudo -u ec2-user -i <<'EOF'
+sudo -u ec2-user -i <<EOF
 
 # PARAMETERS
 PACKAGE=scipy

--- a/scripts/install-server-extension/on-start.sh
+++ b/scripts/install-server-extension/on-start.sh
@@ -5,7 +5,7 @@ set -e
 # OVERVIEW
 # This script installs a single jupyter notebook server extension package in SageMaker Notebook Instance
 
-sudo -u ec2-user -i <<'EOF'
+sudo -u ec2-user -i <<EOF
 
 # PARAMETERS
 PIP_PACKAGE_NAME=jupyterlab-git

--- a/scripts/persistent-conda-ebs/on-create.sh
+++ b/scripts/persistent-conda-ebs/on-create.sh
@@ -12,7 +12,7 @@ set -e
 #
 # For another example, see https://docs.aws.amazon.com/sagemaker/latest/dg/nbi-add-external.html#nbi-isolated-environment
 
-sudo -u ec2-user -i <<'EOF'
+sudo -u ec2-user -i <<EOF
 unset SUDO_UID
 
 # Install a separate conda installation via Miniconda

--- a/scripts/persistent-conda-ebs/on-start.sh
+++ b/scripts/persistent-conda-ebs/on-start.sh
@@ -10,7 +10,7 @@ set -e
 #
 # For another example, see https://docs.aws.amazon.com/sagemaker/latest/dg/nbi-add-external.html#nbi-isolated-environment
 
-sudo -u ec2-user -i <<'EOF'
+sudo -u ec2-user -i <<EOF
 unset SUDO_UID
 
 WORKING_DIR=/home/ec2-user/SageMaker/custom-miniconda/

--- a/scripts/set-git-config/on-start.sh
+++ b/scripts/set-git-config/on-start.sh
@@ -9,7 +9,7 @@ set -e
 YOUR_USER_NAME=your_user_name
 YOUR_EMAIL_ADDRESS=your_email_address
 
-sudo -u ec2-user -i <<'EOF'
+sudo -u ec2-user -i <<EOF
 
 git config --global user.name $YOUR_USER_NAME
 git config --global user.email $YOUR_EMAIL_ADDRESS

--- a/scripts/set-git-config/on-start.sh
+++ b/scripts/set-git-config/on-start.sh
@@ -6,12 +6,12 @@ set -e
 # This script sets username and email address in Git config
 
 # PARAMETERS
-YOUR_USER_NAME=your_user_name
-YOUR_EMAIL_ADDRESS=your_email_address
+YOUR_USER_NAME="your_user_name"
+YOUR_EMAIL_ADDRESS="your_email_address"
 
 sudo -u ec2-user -i <<EOF
 
-git config --global user.name $YOUR_USER_NAME
-git config --global user.email $YOUR_EMAIL_ADDRESS
+git config --global user.name "$YOUR_USER_NAME"
+git config --global user.email "$YOUR_EMAIL_ADDRESS"
 
 EOF


### PR DESCRIPTION
**Issue #, if available:** n/a

**Description of changes:** Any Notebook Instance I created with any of the scripts changed in this PR as their Lifecycle Configuration would time out and fail to start. This is because the delimiter `'EOF'` at the beginning of each `heredoc` had single quotes whereas the delimiter used at the end had none (i.e. `EOF`). This caused the match to fail and the scripts to never complete and return to the shell.

**Testing Done**

- [x] Notebook Instance created successfully with the Lifecycle Configuration
- [x] Notebook Instance stopped and started successfully
- [ ] Documentation in the script around any network access requirements
- [ ] Documentation in the script around any IAM permission requirements
- [x] CLI commands used to validate functionality on the instance
- [ ] New script link and description added to README.md

To test `set-git-config/on-start.sh`:
```bash
$ git config --global user.name
$ git config --global user.email
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
