### PR TITLE
Added single quotes around EOF to resolve error

### DIFF
--- a/scripts/install-conda-package-single-environment/on-start.sh
+++ b/scripts/install-conda-package-single-environment/on-start.sh
@@ -5,7 +5,7 @@ set -e
 # OVERVIEW
 # This script installs a single conda package in a single SageMaker conda environments.
 
-sudo -u ec2-user -i <<EOF
+sudo -u ec2-user -i <<'EOF'
 
 # PARAMETERS
 PACKAGE=scipy


### PR DESCRIPTION
**Issue #, if available:**

Issue #28

**Description of changes:**

Scripts returns a "ArgumentError: Argument --name requires a value." if run as a Start notebook script on AWS SageMaker. 

To resolve this, I added single quotes around EOF and the scripts runs successfully, installing the package specified.

**Testing Done**

- [x] Notebook Instance created successfully with the Lifecycle Configuration
- [x] Notebook Instance stopped and started successfully
- [ ] Documentation in the script around any network access requirements
- [ ] Documentation in the script around any IAM permission requirements
- [x] CLI commands used to validate functionality on the instance
- [ ] New script link and description added to README.md

```
#### new script executed:

#!/bin/bash

set -e

# OVERVIEW
# This script installs a single conda package in a single SageMaker conda environments.
sudo -u ec2-user -i <<'EOF'
# PARAMETERS
PACKAGE=tabulate
ENVIRONMENT=python3
conda install "$PACKAGE" --name "$ENVIRONMENT" --yes
EOF

#### output of script per CloudWatch:

[15:24:04] The following NEW packages will be INSTALLED: tabulate: 0.8.3-py36_0
[15:24:04] Downloading and Extracting Packages
[15:24:04] Preparing transaction: ...working... done
[15:24:04] Verifying transaction: ...working... done
[15:24:04] Executing transaction: ...working... done

#### verification of successful installation

sh-4.2$ conda list tabulate -n "python3"
# packages in environment at /home/ec2-user/anaconda3/envs/python3:
#
# Name                    Version                   Build  Channel
tabulate                  0.8.3                    py36_0
```





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
