### PR TITLE
Fix extension install scripts variable escaping

### DIFF
--- a/scripts/install-lab-extension/on-start.sh
+++ b/scripts/install-lab-extension/on-start.sh
@@ -12,7 +12,7 @@ EXTENSION_NAME=@jupyterlab/git
 
 source /home/ec2-user/anaconda3/bin/activate JupyterSystemEnv
 
-jupyter labextension install $EXTENSION_NAME
+jupyter labextension install \$EXTENSION_NAME
 
 source /home/ec2-user/anaconda3/bin/deactivate
 

--- a/scripts/install-nb-extension/on-start.sh
+++ b/scripts/install-nb-extension/on-start.sh
@@ -14,8 +14,8 @@ EXTENSION_NAME=widgetsnbextension
 
 source /home/ec2-user/anaconda3/bin/activate JupyterSystemEnv
 
-pip install $PIP_PACKAGE_NAME
-jupyter nbextension enable $EXTENSION_NAME --py --sys-prefix
+pip install \$PIP_PACKAGE_NAME
+jupyter nbextension enable \$EXTENSION_NAME --py --sys-prefix
 
 source /home/ec2-user/anaconda3/bin/deactivate
 


### PR DESCRIPTION
**Issue #, if available:** #32 

**Description of changes:** Escape $ in variable names within the `sudo -u ec2-user -i <<EOF` pattern; which are otherwise resolved by the outer shell before passing to the subshell.

**Testing Done**

- [X] Notebook Instance created successfully with the Lifecycle Configuration
- [X] Notebook Instance stopped and started successfully
- [ ] ~Documentation in the script around any network access requirements~
- [ ] ~Documentation in the script around any IAM permission requirements~
- [X] CLI commands used to validate functionality on the instance
- [ ] ~New script link and description added to README.md~

```
jupyter labextension list
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
