### PR TITLE
Added a script to configure private pypi repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Lifecycle Configurations provide a mechanism to customize Notebook Instances via
 
 #### Sample Scripts
 
+* [add-pypi-repository](scripts/add-pypi-repository) - This script adds a private PyPi repository in addition to or instead of pypi.org.
 * [auto-stop-idle](scripts/auto-stop-idle) - This script stops a SageMaker notebook once it's idle for more than 1 hour. (default time)
 * [connect-emr-cluster](scripts/connect-emr-cluster) - This script connects an EMR cluster to the Notebook Instance using SparkMagic.
 * [disable-uninstall-ssm-agent](scripts/disable-uninstall-ssm-agent) - This script disables and uninstalls the SSM Agent at startup.

--- a/scripts/add-pypi-repository/on-start.sh
+++ b/scripts/add-pypi-repository/on-start.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -e
+
+# OVERVIEW:
+# This script adds an alternate PyPi repository to be used by `pip install ...`. 
+# 
+# You can use this script to connect to your organization's private PyPi repository. 
+# There are two common reasons for using private PyPi repositories and this script is 
+# set up to support both.
+# 1. You have a repository that you want to use to host your organization's own packages
+#    *in addition to* the main pypi.org repository. In that case, set DISABLE_PYPI, below,
+#    to false and the setup will allow `pip install` to search both repositories.
+# 2. You have a repository that hosts a set of curated packages that are approved for use
+#    in your organization. This is common in organizations that have strict regulatory
+#    or security requirements. In this case, set DISABLE_PYPI to true and pip will be
+#    be configured to search *only* your private repository.
+#
+# For other requirements (like multiple repositories), feel free to edit this script to
+# meet your needs.
+#
+# See the pip documentation at https://pip.pypa.io/en/stable/user_guide/#config-file for 
+# details on how the pip configuration file works.
+
+# The URL of your repository
+PYPI_URL=<Your respository url here>
+
+# If DISABLE_PYPI is true, pip will ignore the pypi.org repository and only use the defined
+# repository. If it is false, pip will use the defined repository *in addition to* 
+# pypi.org
+DISABLE_PYPI=false
+
+# If ADD_TRUST is true, tell pip to trust the specified server even if the certificate
+# doesn't validate.
+ADD_TRUST=true
+
+if [ "$DISABLE_PYPI" == "true" ]
+then
+    extra=""
+else
+    extra="extra-"
+fi
+
+if [ "$ADD_TRUST" == "true" ]
+then
+    pypi_host=$(sed 's%^[^/]*//\([^/:]*\)[:/].*$%\1%' <<< "${PYPI_URL}")
+    trusted_host="trusted-host = ${pypi_host}"
+else
+    trusted_host=""
+fi
+
+mkdir ~ec2-user/.pip
+
+cat > ~ec2-user/.pip/pip.conf <<END
+[global]
+${extra}index-url = ${PYPI_URL}
+${trusted_host}
+END
+
+chown -R ec2-user:ec2-user ~ec2-user/.pip


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Subject says it all. 

**Testing Done**

- [x] Notebook Instance created successfully with the Lifecycle Configuration
- [x] Notebook Instance stopped and started successfully
- [x] Documentation in the script around any network access requirements
- [x] Documentation in the script around any IAM permission requirements
- [x] CLI commands used to validate functionality on the instance
- [x] New script link and description added to README.md

Provide your commands here

I set up a private repo on an ec2 node in my VPC and was able to install a custom package that
doesn't exist in the regular PyPi repo. 

Also confirmed that, if I set DISABLE_PYPI, it looks only at the private index. 

Tested with and without direct internet connection enabled.

```
sh-4.2$ pip install sagemaker_run_notebook
Looking in indexes: http://172.31.24.20:8080/
Collecting sagemaker_run_notebook
  Downloading http://172.31.24.20:8080/packages/sagemaker_run_notebook-0.0.1.tar.gz (9.1 kB)
Requirement already satisfied: boto3>=1.10.44 in ./anaconda3/envs/JupyterSystemEnv/lib/python3.6/site-packages (from sagemaker_run_notebook) (1.12.27)
Requirement already satisfied: s3transfer<0.4.0,>=0.3.0 in ./anaconda3/envs/JupyterSystemEnv/lib/python3.6/site-packages (from boto3>=1.10.44->sagemaker_run_notebook) (0.3.3)
Requirement already satisfied: jmespath<1.0.0,>=0.7.1 in ./anaconda3/envs/JupyterSystemEnv/lib/python3.6/site-packages (from boto3>=1.10.44->sagemaker_run_notebook) (0.9.4)
Requirement already satisfied: botocore<1.16.0,>=1.15.27 in ./anaconda3/envs/JupyterSystemEnv/lib/python3.6/site-packages (from boto3>=1.10.44->sagemaker_run_notebook) (1.15.27)
Requirement already satisfied: urllib3<1.26,>=1.20; python_version != "3.4" in ./anaconda3/envs/JupyterSystemEnv/lib/python3.6/site-packages (from botocore<1.16.0,>=1.15.27->boto3>=1.10.44->sagemaker_run_notebook) (1.22)
Requirement already satisfied: python-dateutil<3.0.0,>=2.1 in ./anaconda3/envs/JupyterSystemEnv/lib/python3.6/site-packages (from botocore<1.16.0,>=1.15.27->boto3>=1.10.44->sagemaker_run_notebook) (2.8.1)
Requirement already satisfied: docutils<0.16,>=0.10 in ./anaconda3/envs/JupyterSystemEnv/lib/python3.6/site-packages (from botocore<1.16.0,>=1.15.27->boto3>=1.10.44->sagemaker_run_notebook) (0.15.2)
Requirement already satisfied: six>=1.5 in ./anaconda3/envs/JupyterSystemEnv/lib/python3.6/site-packages (from python-dateutil<3.0.0,>=2.1->botocore<1.16.0,>=1.15.27->boto3>=1.10.44->sagemaker_run_notebook) (1.14.0)
Building wheels for collected packages: sagemaker-run-notebook
  Building wheel for sagemaker-run-notebook (setup.py) ... done
  Created wheel for sagemaker-run-notebook: filename=sagemaker_run_notebook-0.0.1-py3-none-any.whl size=11108 sha256=f85a38666fc5356f0651205a96af67b11e863520cccaa40ecf15eaa25aa673c3
  Stored in directory: /home/ec2-user/.cache/pip/wheels/8a/d3/c1/12f5226469bf54137fb90a1067fdd2896a957c0581326f4d04
Successfully built sagemaker-run-notebook
Installing collected packages: sagemaker-run-notebook
Successfully installed sagemaker-run-notebook-0.0.1
sh-4.2$ 
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
