### PR TITLE
Fix crontab for autostop when idle

### DIFF
--- a/scripts/auto-stop-idle/on-start.sh
+++ b/scripts/auto-stop-idle/on-start.sh
@@ -21,4 +21,4 @@ wget https://raw.githubusercontent.com/aws-samples/amazon-sagemaker-notebook-ins
 
 echo "Starting the SageMaker autostop script in cron"
 
-(crontab -l 2>/dev/null; echo "5 * * * * /usr/bin/python $PWD/autostop.py --time $IDLE_TIME --ignore-connections") | crontab -
+(crontab -l 2>/dev/null; echo "*/5 * * * * /usr/bin/python $PWD/autostop.py --time $IDLE_TIME --ignore-connections") | crontab -


### PR DESCRIPTION
**Issue # , if available:** #40 

**Description of changes:** Fix _auto_stop_idle.sh_ crontab to run _autostop.py_ script every 5 minutes.

**Testing Done**

- [x] Notebook Instance created successfully with the Lifecycle Configuration
- [x] Notebook Instance stopped and started successfully


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
