### PR TITLE
Edit persist envs script to make kernel available in dropdown

### DIFF
--- a/scripts/persistent-conda-ebs/on-create.sh
+++ b/scripts/persistent-conda-ebs/on-create.sh
@@ -37,4 +37,7 @@ pip install --quiet ipykernel
 conda install --yes numpy
 pip install --quiet boto3
 
+# Make the custom kernel available in dropdown
+python -m ipykernel install --user --name=$KERNEL_NAME
+
 EOF


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Added a line in the persist-envs on_create script to make the custom kernel available in the dropdown list in the "New" menu
**Testing Done**

- [ X] Notebook Instance created successfully with the Lifecycle Configuration
- [X ] Notebook Instance stopped and started successfully
- [ ] Documentation in the script around any network access requirements
- [ ] Documentation in the script around any IAM permission requirements
- [ ] CLI commands used to validate functionality on the instance
- [ ] New script link and description added to README.md

```
# Provide your commands here
/you/commands/here
```





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
