### PR TITLE
Change: Script to enable running Streamlit webapp on SageMaker instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Lifecycle Configurations provide a mechanism to customize Notebook Instances via
 * [auto-stop-idle](scripts/auto-stop-idle) - This script stops a SageMaker notebook once it's idle for more than 1 hour. (default time)
 * [connect-emr-cluster](scripts/connect-emr-cluster) - This script connects an EMR cluster to the Notebook Instance using SparkMagic.
 * [disable-uninstall-ssm-agent](scripts/disable-uninstall-ssm-agent) - This script disables and uninstalls the SSM Agent at startup.
+* [enable-streamlit-webapp-proxy](scripts/enable-streamlit-webapp-proxy) - This script enables Streamlit webapp to run on SageMaker instance.
 * [execute-notebook-on-startup](scripts/execute-notebook-on-startup) - This script executes a Notebook file on the instance during startup.
 * [export-to-pdf-enable](scripts/export-to-pdf-enable) - This script enables Jupyter to export a notebook directly to PDF.
 * [install-conda-package-all-environments](scripts/install-conda-package-all-environments) - This script installs a single conda package in all SageMaker conda environments, apart from the JupyterSystemEnv which is a system environment reserved for Jupyter.

--- a/scripts/enable-streamlit-webapp-proxy/on-start.sh
+++ b/scripts/enable-streamlit-webapp-proxy/on-start.sh
@@ -3,7 +3,7 @@
 set -e
 
 # OVERVIEW
-# This script installs a jupyter-server-proxy in SageMaker Notebook Instance
+# This script enable Streamlit webapp to run on SageMaker notebook instance.
 #
 # By default Streamlit is installed in `python3` virtual environment. Start Streamlit server by running the following command in notebook terminal:
 # - source activate python3

--- a/scripts/enable-streamlit-webapp-proxy/on-start.sh
+++ b/scripts/enable-streamlit-webapp-proxy/on-start.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e
+
+# OVERVIEW
+# This script installs a jupyter-server-proxy in SageMaker Notebook Instance
+#
+# By default Streamlit is installed in `python3` virtual environment. Start Streamlit server by running the following command in notebook terminal:
+# - source activate python3
+# - streamlit run app.py
+#
+# Streamlit web app can be accessed using the URL `{base_url}/proxy/{port}/` in a browser. With a slash at the end.
+# E.g. https://{notebookname}.notebook.{region}.sagemaker.aws/proxy/8501/
+
+
+sudo -u ec2-user -i <<'EOF'
+# PARAMETERS
+source /home/ec2-user/anaconda3/bin/activate JupyterSystemEnv
+
+# Disable nbserverproxy
+jupyter serverextension disable --py nbserverproxy
+
+cp /home/ec2-user/anaconda3/envs/JupyterSystemEnv/etc/jupyter/jupyter_notebook_config.json \
+/home/ec2-user/anaconda3/envs/JupyterSystemEnv/etc/jupyter/jupyter_notebook_config.json.bk
+sed 's/"nbserverproxy": true/"nbserverproxy": false/g' /home/ec2-user/anaconda3/envs/JupyterSystemEnv/etc/jupyter/jupyter_notebook_config.json.bk \
+> /home/ec2-user/anaconda3/envs/JupyterSystemEnv/etc/jupyter/jupyter_notebook_config.json
+
+# Uninstall nbserverproxy
+pip uninstall nbserverproxy --yes
+
+# Install jupyter-server-proxy
+pip install jupyter-server-proxy
+
+# Activate environment for Streamlit installation
+ENVIRONMENT=python3
+source /home/ec2-user/anaconda3/bin/activate "$ENVIRONMENT"
+pip install streamlit
+
+# Restart jupyter server
+sudo initctl restart jupyter-server --no-wait
+
+source /home/ec2-user/anaconda3/bin/deactivate
+
+
+EOF
+


### PR DESCRIPTION
**Issue #, if available:**
NA

**Description of changes:**
Script to enable running Streamlit webapp on SageMaker instance. This allow user to easily showcase visualization on Streamlit using existing SageMaker notebook instance.

**Testing Done**

- [x] Notebook Instance created successfully with the Lifecycle Configuration
- [x] Notebook Instance stopped and started successfully
- [x] ~~Documentation in the script around any network access requirements~~
- [x] ~~Documentation in the script around any IAM permission requirements~~
- [x] CLI commands used to validate functionality on the instance
- [x] New script link and description added to README.md


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
