### PR TITLE
Added new script for persisting history to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Lifecycle Configurations provide a mechanism to customize Notebook Instances via
 * [install-server-extension](scripts/install-server-extension) - This script installs a single jupyter notebook server extension package in SageMaker Notebook Instance.
 * [mount-efs-file-system](scripts/mount-efs-file-system) - This script mounts an EFS file system to the Notebook Instance at the ~/SageMaker/efs directory based off the DNS name.
 * [mount-fsx-lustre-file-system](scripts/mount-fsx-lustre-file-system) - This script mounts an FSx for Lustre file system to the Notebook Instance at the /fsx directory based off the DNS and Mount name parameters.
+* [notebook-history-s3](scripts/notebook-history-s3) - This script persists the underlying sqlite database of commands and cells executed for S3.
 * [persistent-conda-ebs](scripts/persistent-conda-ebs) - This script installs a custom, persistent installation of conda on the Notebook Instance's EBS volume, and ensures that these custom environments are available as kernels in Jupyter.
 * [proxy-for-jupyter](scripts/proxy-for-jupyter) - This script configures proxy settings for your Jupyter notebooks and the SageMaker Notebook Instance.
 * [publish-instance-metrics](scripts/publish-instance-metrics) - This script publishes the system-level metrics from the Notebook Instance to CloudWatch.

--- a/scripts/notebook-history-s3/notebook-history-s3.py
+++ b/scripts/notebook-history-s3/notebook-history-s3.py
@@ -1,0 +1,65 @@
+#     Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License").
+#     You may not use this file except in compliance with the License.
+#     A copy of the License is located at
+#
+#         https://aws.amazon.com/apache-2-0/
+#
+#     or in the "license" file accompanying this file. This file is distributed
+#     on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+#     express or implied. See the License for the specific language governing
+#     permissions and limitations under the License.
+
+import requests
+from datetime import datetime
+import getopt, sys
+import boto3
+import json
+import sagemaker
+import urllib3
+import logging
+
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+# Usage
+usageInfo = """Usage:
+This scripts gets the sqllite database of sessions and jupyter history and writes the spllite files to S3:
+python log_notebook_history. Type "python autostop.py -h" for available options.
+"""
+
+# Help info
+helpInfo = """
+-h, --help
+    Help information
+"""
+logging.basicConfig(level=logging.INFO, format='%(message)s')
+logger = logging.getLogger()
+logger.addHandler(logging.FileHandler('/var/log/notebook_history_s3.log', 'a'))
+
+# Read in command-line parameters
+try:
+    opts, args = getopt.getopt(sys.argv[1:], "h", ["help"])
+    for opt, arg in opts:
+        if opt in ("-h", "--help"):
+            print(helpInfo)
+            exit(0)
+except getopt.GetoptError:
+    print(usageInfo)
+    exit(1)
+
+def get_notebook_name():
+    log_path = "/opt/ml/metadata/resource-metadata.json"
+    with open(log_path, "r") as logs:
+        _logs = json.load(logs)
+    return _logs["ResourceName"]
+
+sagemaker_session = sagemaker.Session()
+s3 = boto3.client("s3")
+bucket = sagemaker_session.default_bucket()
+key = "notebooks/{}/history/{}/history.sqlite".format(get_notebook_name(), datetime.now().strftime("%Y%m%d-%H%M%S"))
+
+logger.info("Writing history.sqlite to {}/{}".format(bucket,key))
+with open('/home/ec2-user/.ipython/profile_default/history.sqlite', 'rb') as data:
+    s3.upload_fileobj(data, bucket, key)

--- a/scripts/notebook-history-s3/on-start.sh
+++ b/scripts/notebook-history-s3/on-start.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+# OVERVIEW
+# This script logs the history of a notebook server to S3 once an hour/
+#
+# Note that this script will fail if either condition is not met
+#   1. Ensure the Notebook Instance has internet connectivity to fetch the example config
+#   2. Ensure the Notebook Instance execution role permissions to write a file to the Sagemaker default bucket
+
+# DEPENDENCIES
+pip install sagemaker
+
+# PARAMETERS
+echo "Fetching the log history script"
+wget https://raw.githubusercontent.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples/master/scripts/notebook-history-s3/on-start.sh
+echo "Starting the SageMaker logging script in cron"
+
+(crontab -l 2>/dev/null; echo "0 * * * * /usr/bin/python3 $PWD/notebook_history_s3.py") | crontab -

--- a/scripts/notebook-history-s3/on-start.sh
+++ b/scripts/notebook-history-s3/on-start.sh
@@ -14,7 +14,7 @@ pip install sagemaker
 
 # PARAMETERS
 echo "Fetching the log history script"
-wget https://raw.githubusercontent.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples/master/scripts/notebook-history-s3/on-start.sh
+wget https://raw.githubusercontent.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples/master/scripts/notebook-history-s3/notebook-history-s3.py
 echo "Starting the SageMaker logging script in cron"
 
 (crontab -l 2>/dev/null; echo "0 * * * * /usr/bin/python3 $PWD/notebook_history_s3.py") | crontab -


### PR DESCRIPTION
**Issue #, if available:**
N/a

**Description of changes:**
Adds a script which writes the sqlite db to S3. This DB can be used to see cell execution history as well as session history.

When testing, you will have to modify the on-start.sh to point to the correct location for the raw python script location, as that location won't become valid until the changes are merged to master. My testing steps are below and require no modification to run.

**Testing Done**

- [x] Notebook Instance created successfully with the Lifecycle Configuration
- [x] Notebook Instance stopped and started successfully
- [x] Documentation in the script around any network access requirements
- [x] Documentation in the script around any IAM permission requirements
- [x] CLI commands used to validate functionality on the instance
- [x] New script link and description added to README.md

```
sudo su
export PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
cd /

mkdir /scripts
mkdir /scripts/notebook-history-s3
cd /scripts/notebook-history-s3

wget https://raw.githubusercontent.com/jmgray24/amazon-sagemaker-notebook-instance-lifecycle-config-samples/master/scripts/notebook-history-s3/on-start.sh

sh on-start.sh
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
