### PR TITLE
add script to upgrade to SageMaker Python SDK v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Lifecycle Configurations provide a mechanism to customize Notebook Instances via
 * [publish-instance-metrics](scripts/publish-instance-metrics) - This script publishes the system-level metrics from the Notebook Instance to CloudWatch.
 * [set-env-variable](scripts/set-env-variable) - This script gets a value from the Notebook Instance's tags and sets it as an environment variable for all processes including Jupyter.
 * [set-git-config](scripts/set-git-config) - This script sets the username and email address in Git config.
+* [upgrade-to-sagemaker-python-sdk-v2](scripts/upgrade-to-sagemaker-python-sdk-v2) - This script upgrades the SageMaker Python SDK to v2 in all Python 3 environments.
 
 ### Development
 

--- a/scripts/upgrade-to-sagemaker-python-sdk-v2/on-start.sh
+++ b/scripts/upgrade-to-sagemaker-python-sdk-v2/on-start.sh
@@ -15,10 +15,15 @@ for env in base /home/ec2-user/anaconda3/envs/*; do
     py_version=$(python -c 'import sys; print(sys.version_info[0])')
 
     if [ $env == 'JupyterSystemEnv' ] || [ $py_version == 2 ]; then
+        echo "Skipping upgrade of the SageMaker Python SDK in $env."
         continue
     fi
 
+    echo "Upgrading the SageMaker Python SDK in $env..."
+
     pip install --upgrade 'sagemaker>2'
+
+    echo "Upgraded the SageMaker Python SDK in $env."
 
     source /home/ec2-user/anaconda3/bin/deactivate
 done

--- a/scripts/upgrade-to-sagemaker-python-sdk-v2/on-start.sh
+++ b/scripts/upgrade-to-sagemaker-python-sdk-v2/on-start.sh
@@ -14,7 +14,7 @@ for env in base /home/ec2-user/anaconda3/envs/*; do
 
     py_version=$(python -c 'import sys; print(sys.version_info[0])')
 
-    if [ $env == 'JupyterSystemEnv' ] || [ py_version == '2' ]; then
+    if [ $env == 'JupyterSystemEnv' ] || [ $py_version == 2 ]; then
         continue
     fi
 

--- a/scripts/upgrade-to-sagemaker-python-sdk-v2/on-start.sh
+++ b/scripts/upgrade-to-sagemaker-python-sdk-v2/on-start.sh
@@ -3,7 +3,7 @@
 set -e
 
 # OVERVIEW
-# This script upgrades the SageMaker Python SDK to v2 in all environments.
+# This script upgrades the SageMaker Python SDK to v2 in all Python 3 environments.
 #
 # For more details, see https://sagemaker.readthedocs.io/en/stable/v2.html
 
@@ -12,7 +12,9 @@ sudo -u ec2-user -i <<'EOF'
 for env in base /home/ec2-user/anaconda3/envs/*; do
     source /home/ec2-user/anaconda3/bin/activate $(basename "$env")
 
-    if [ $env = 'JupyterSystemEnv' ]; then
+    py_version=$(python -c 'import sys; print(sys.version_info[0])')
+
+    if [ $env == 'JupyterSystemEnv' ] || [ py_version == '2' ]; then
         continue
     fi
 

--- a/scripts/upgrade-to-sagemaker-python-sdk-v2/on-start.sh
+++ b/scripts/upgrade-to-sagemaker-python-sdk-v2/on-start.sh
@@ -18,7 +18,7 @@ for env in base /home/ec2-user/anaconda3/envs/*; do
         continue
     fi
 
-    pip install --upgrade sagemaker>2
+    pip install --upgrade 'sagemaker>2'
 
     source /home/ec2-user/anaconda3/bin/deactivate
 done

--- a/scripts/upgrade-to-sagemaker-python-sdk-v2/on-start.sh
+++ b/scripts/upgrade-to-sagemaker-python-sdk-v2/on-start.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+# OVERVIEW
+# This script upgrades the SageMaker Python SDK to v2 in all environments.
+#
+# For more details, see https://sagemaker.readthedocs.io/en/stable/v2.html
+
+sudo -u ec2-user -i <<'EOF'
+
+for env in base /home/ec2-user/anaconda3/envs/*; do
+    source /home/ec2-user/anaconda3/bin/activate $(basename "$env")
+
+    if [ $env = 'JupyterSystemEnv' ]; then
+        continue
+    fi
+
+    pip install --upgrade sagemaker>2
+
+    source /home/ec2-user/anaconda3/bin/deactivate
+done
+
+EOF


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/aws/sagemaker-python-sdk/issues/1459

**Description of changes:**
This script upgrades the SageMaker Python SDK to v2 in all Python 3 environments.

**Testing Done**
- [x] Notebook Instance created successfully with the Lifecycle Configuration
- [x] Notebook Instance stopped and started successfully
- [ ] Documentation in the script around any network access requirements
- [ ] Documentation in the script around any IAM permission requirements
- [x] CLI commands used to validate functionality on the instance
- [x] New script link and description added to README.md

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
