### PR TITLE
Add cross-account CodeCommit access

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Lifecycle Configurations provide a mechanism to customize Notebook Instances via
 * [persistent-conda-ebs](scripts/persistent-conda-ebs) - This script installs a custom, persistent installation of conda on the Notebook Instance's EBS volume, and ensures that these custom environments are available as kernels in Jupyter.
 * [proxy-for-jupyter](scripts/proxy-for-jupyter) - This script configures proxy settings for your Jupyter notebooks and the SageMaker Notebook Instance.
 * [publish-instance-metrics](scripts/publish-instance-metrics) - This script publishes the system-level metrics from the Notebook Instance to CloudWatch.
+* [set-codecommit-cross-account-access](scripts/set-codecommit-cross-account-access) - This script sets cross-account CodeCommit access, so you can work on repositories hosted in another account.
 * [set-env-variable](scripts/set-env-variable) - This script gets a value from the Notebook Instance's tags and sets it as an environment variable for all processes including Jupyter.
 * [set-git-config](scripts/set-git-config) - This script sets the username and email address in Git config.
 

--- a/scripts/set-codecommit-cross-account-access/on-start.sh
+++ b/scripts/set-codecommit-cross-account-access/on-start.sh
@@ -10,7 +10,7 @@ set -e
 # https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-https-unixes.html#setting-up-https-unixes-credential-helper
 
 # PARAMETERS
-ROLE_ARN=arn:aws:iam::YourAccount:role/YourCrossAccountRepoAccess-Role
+ROLE_ARN=arn:aws:iam::CodeCommitAccount:role/CrossAccountRepositoryContributorRole
 REGION=us-east-1
 
 sudo -u ec2-user -i <<EOF

--- a/scripts/set-codecommit-cross-account-access/on-start.sh
+++ b/scripts/set-codecommit-cross-account-access/on-start.sh
@@ -23,6 +23,6 @@ cat >>/home/ec2-user/.aws/config <<-END_CAT
 	output = json
 END_CAT
 
-git config --global credential.helper '!aws --profile CodeCommitProfile codecommit credential-helper $@'
+git config --global credential.helper '!aws --profile CrossAccountAccessProfile codecommit credential-helper $@'
 
 EOF

--- a/scripts/set-codecommit-cross-account-access/on-start.sh
+++ b/scripts/set-codecommit-cross-account-access/on-start.sh
@@ -16,7 +16,7 @@ REGION=us-east-1
 sudo -u ec2-user -i <<EOF
 
 cat >>/home/ec2-user/.aws/config <<-END_CAT
-	[profile CodeCommitProfile]
+	[profile CrossAccountAccessProfile]
 	region = $REGION
 	role_arn = $ROLE_ARN
 	credential_source = Ec2InstanceMetadata

--- a/scripts/set-codecommit-cross-account-access/on-start.sh
+++ b/scripts/set-codecommit-cross-account-access/on-start.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+# OVERVIEW
+# This script sets cross-account CodeCommit access, so you can work on repositories hosted in another account.
+# You'll need to create a role in AccountA granting repositories access to AccountB as instructed here:
+# https://docs.aws.amazon.com/sagemaker/latest/dg/nbi-git-cross.html
+# More information about the credential helper here:
+# https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-https-unixes.html#setting-up-https-unixes-credential-helper
+
+# PARAMETERS
+ROLE_ARN=arn:aws:iam::YourAccount:role/YourCrossAccountRepoAccess-Role
+REGION=us-east-1
+
+sudo -u ec2-user -i <<EOF
+
+cat >>/home/ec2-user/.aws/config <<-END_CAT
+	[profile CodeCommitProfile]
+	region = $REGION
+	role_arn = $ROLE_ARN
+	credential_source = Ec2InstanceMetadata
+	output = json
+END_CAT
+
+git config --global credential.helper '!aws --profile CodeCommitProfile codecommit credential-helper $@'
+
+EOF


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adds a script that configures cross-account access to CodeCommit repositories in another account. It basically automates the steps 3 and 4 of the instructions [here](https://docs.aws.amazon.com/sagemaker/latest/dg/nbi-git-cross.html) that would need to be executed every time the notebook is started otherwise.

**Testing Done**

- [x] Notebook Instance created successfully with the Lifecycle Configuration
- [x] Notebook Instance stopped and started successfully
- [ ] Documentation in the script around any network access requirements
- [x] Documentation in the script around any IAM permission requirements
- [x] CLI commands used to validate functionality on the instance
- [x] New script link and description added to README.md

```shell
cat ~/.aws/config  # notice there's only the default profile
cat ~/.gitconfig # notice credential helper doesn't have --profile

# it's going to raise an error
git clone <my_https_clone_url_from_another_account>

# download the script
wget https://raw.githubusercontent.com/tuliocasagrande/amazon-sagemaker-notebook-instance-lifecycle-config-samples/master/scripts/set-codecommit-cross-account-access/on-start.sh

# add IAM Role ARN of account A
vim on-start.sh # or nano on-start.sh

# execute the script
bash on-start.sh

cat ~/.aws/config  # notice the new profile
cat ~/.gitconfig # notice credential helper with newprofile

# repeat git clone command, it's going to succeed
git clone <my_https_clone_url_from_another_account>
```





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
