### PR TITLE
Add example to pip install to Py3+ envs only

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Lifecycle Configurations provide a mechanism to customize Notebook Instances via
 * [install-nb-extension](scripts/install-nb-extension) - This script installs a single jupyter notebook extension package in SageMaker Notebook Instance.
 * [install-pip-package-all-environments](scripts/install-pip-package-all-environments) - This script installs a single pip package in all SageMaker conda environments, apart from the JupyterSystemEnv which is a system environment reserved for Jupyter.
 * [install-pip-package-single-environment](scripts/install-pip-package-single-environment) - This script installs a single pip package in a single SageMaker conda environments.
+* [install-pip-packages-py3-environments](scripts/install-pip-packages-py3-environments) - This script installs one or more pip packages in all SageMaker conda environments running Python 3, excluding the JupyterSystemEnv (which is a system environment reserved for Jupyter) and any Python 2 environments.
 * [install-server-extension](scripts/install-server-extension) - This script installs a single jupyter notebook server extension package in SageMaker Notebook Instance.
 * [mount-efs-file-system](scripts/mount-efs-file-system) - This script mounts an EFS file system to the Notebook Instance at the ~/SageMaker/efs directory based off the DNS name.
 * [mount-fsx-lustre-file-system](scripts/mount-fsx-lustre-file-system) - This script mounts an FSx for Lustre file system to the Notebook Instance at the /fsx directory based off the DNS and Mount name parameters.

--- a/scripts/install-pip-packages-py3-environments/on-start.sh
+++ b/scripts/install-pip-packages-py3-environments/on-start.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+# OVERVIEW
+# This script installs one or more pip packages in all SageMaker conda environments running Python v3, apart from the
+# JupyterSystemEnv which is a system environment reserved for Jupyter.
+#
+# Note this may timeout if the package installations in all environments take longer than 5 mins, consider using
+# "nohup" to run this as a background process in that case.
+
+sudo -u ec2-user -i <<'EOF'
+# PARAMETERS
+PACKAGES='sagemaker-experiments smdebug'
+
+# Note that "base" is special environment name that you could also consider omitting, but we include it here
+for env in base /home/ec2-user/anaconda3/envs/*; do
+    source /home/ec2-user/anaconda3/bin/activate $(basename "$env")
+    if [ $env = 'JupyterSystemEnv' ]; then
+        echo "Skipping JupyterSystemEnv"
+        continue
+    elif ! [[ "$(python -V 2>&1)" =~ Python\ 3 ]]; then
+        echo "Skipping Python 2 environment $env"
+        continue
+    fi
+    # `eval` here allows $PACKAGES to be multiple rather than one only:
+    eval pip install --upgrade "$PACKAGES"
+    source /home/ec2-user/anaconda3/bin/deactivate
+done
+EOF


### PR DESCRIPTION
**Issue #, if available:** #55

**Description of changes:**

Add a new `install-pip-packages-py3-environments` example to demonstrate installing the `smdebug` and `sagemaker-experiments` libraries on all kernels except JupyterSystemEnv - excluding any running Python 2 (which these libraries don't support).

This sample also extends over `install-pip-package-all-environments` by accepting multiple packages in the parameter.

**Testing Done**

- [X] Notebook Instance created successfully with the Lifecycle Configuration
- [X] Notebook Instance stopped and started successfully
- [ ] Documentation in the script around any network access requirements (See below)
- [ ] Documentation in the script around any IAM permission requirements (See below)
- [X] CLI commands used to validate functionality on the instance
- [X] New script link and description added to README.md

Open consoles from the launcher in the various Python environments. `smdebug` and `smexperiments` are importable in Python 3.x kernels but not Python 2.x

No explicit docs in the script about what network/IAM access is required, but comments are in line with existing samples covering same topics (e.g. `install-pip-package-all-environments`)


<br/><br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
