### PR TITLE
Adding two new scripts to help migrate data from an existing instance to a new instance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Lifecycle Configurations provide a mechanism to customize Notebook Instances via
 * [install-pip-package-single-environment](scripts/install-pip-package-single-environment) - This script installs a single pip package in a single SageMaker conda environments.
 * [install-r-package](scripts/install-r-package) - This script installs a single R package in SageMaker R environment.
 * [install-server-extension](scripts/install-server-extension) - This script installs a single jupyter notebook server extension package in SageMaker Notebook Instance.
+* [migrate-ebs-data-backup](scripts/migrate-ebs-data-backup) - This script backs up content in `/home/ec2-user/SageMaker/` to a S3 bucket specified in a tag on the notebook instance.
+* [migrate-ebs-data-sync](scripts/migrate-ebs-data-sync) - This script downloads a snapshot created by [migrate-ebs-data-backup](scripts/migrate-ebs-data-backup) to `/home/ec2-user/SageMaker/` in a new notebook instance. You specify the snapshop using tags on the notebook instance.
 * [mount-efs-file-system](scripts/mount-efs-file-system) - This script mounts an EFS file system to the Notebook Instance at the ~/SageMaker/efs directory based off the DNS name.
 * [mount-fsx-lustre-file-system](scripts/mount-fsx-lustre-file-system) - This script mounts an FSx for Lustre file system to the Notebook Instance at the /fsx directory based off the DNS and Mount name parameters.
 * [notebook-history-s3](scripts/notebook-history-s3) - This script persists the underlying sqlite database of commands and cells executed for S3.

--- a/scripts/migrate-ebs-data-backup/on-start.sh
+++ b/scripts/migrate-ebs-data-backup/on-start.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+cat << "EOF" > /home/ec2-user/backup.sh
+#!/bin/bash
+NOTEBOOK_ARN=$(jq '.ResourceArn' /opt/ml/metadata/resource-metadata.json --raw-output)
+NOTEBOOK_NAME=$(jq '.ResourceName' /opt/ml/metadata/resource-metadata.json --raw-output)
+BACKUP_DESTINATION=ebs-backup-bucket
+BUCKET=$(aws sagemaker list-tags --resource-arn $NOTEBOOK_ARN  | jq -r --arg BACKUP_DESTINATION "$BACKUP_DESTINATION" .'Tags[] | select(.Key == $BACKUP_DESTINATION).Value' --raw-output)
+# check if bucket exists
+# if not, create a bucket
+echo "Checking if s3://${BUCKET} exists..."
+aws s3api wait bucket-exists --bucket $BUCKET || (echo "s3://${BUCKET} does not exist, creating..."; aws s3 mb s3://${BUCKET})
+TIMESTAMP=`date +%F-%H-%M-%S`
+SNAPSHOT=${NOTEBOOK_NAME}_${TIMESTAMP}
+echo "Backup up /home/ec2-user/SageMaker/ to s3://${BUCKET}/${SNAPSHOT}/"
+aws s3 sync --exclude "*/lost+found/*" /home/ec2-user/SageMaker/ s3://${BUCKET}/${SNAPSHOT}/
+exitcode=$?
+echo $exitcode
+if [ $exitcode -eq 0 ] || [ $exitcode -eq 2 ]
+then
+    TIMESTAMP=`date +%F-%H-%M-%S`
+    echo "Created s3://${BUCKET}/${SNAPSHOT}/" > /home/ec2-user/SageMaker/BACKUP_COMPLETE
+    echo "Completed at $TIMESTAMP" >> /home/ec2-user/SageMaker/BACKUP_COMPLETE
+    aws s3 cp /home/ec2-user/SageMaker/BACKUP_COMPLETE s3://${BUCKET}/${SNAPSHOT}/BACKUP_COMPLETE
+fi
+EOF
+
+chmod +x /home/ec2-user/backup.sh
+chown ec2-user:ec2-user /home/ec2-user/backup.sh
+
+# nohup to bypass the notebook instance timeout at start
+sudo -u ec2-user nohup /home/ec2-user/backup.sh >>  /home/ec2-user/nohup.out 2>&1 & 

--- a/scripts/migrate-ebs-data-backup/on-start.sh
+++ b/scripts/migrate-ebs-data-backup/on-start.sh
@@ -6,7 +6,7 @@ set -e
 #
 # The snapshot can be download into a new instance using https://github.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples/tree/master/scripts/migrate-ebs-data-sync/on-create.sh.
 # 
-# Note that the execution is done with nohup to bypass the startup timeout set by SageMaker Notebook instance. Depending on the size of the source /home/ec2-user/SageMaker/, it may take more than 5 minutes. You would see a text file BACKUP_COMPLETE created in /home/ec2-user/SageMaker/ and in the S3 bucket to denote the completion.
+# Note that the execution is done with nohup to bypass the startup timeout set by SageMaker Notebook instance. Depending on the size of the source /home/ec2-user/SageMaker/, it may take more than 5 minutes. You would see a text file BACKUP_COMPLETE created in /home/ec2-user/SageMaker/ and in the S3 bucket to denote the completion. You need s3:CreateBucket, s3:GetObject, s3:PutObject, and s3:ListBucket in the execution role to perform aws s3 sync.
 #
 # Note if your notebook instance is in VPC mode without a direct internet access, please create a S3 VPC Gateway endpoint (https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-s3.html) and a SageMaker API VPC interface endpoint (https://docs.aws.amazon.com/sagemaker/latest/dg/interface-vpc-endpoint.html).
 #

--- a/scripts/migrate-ebs-data-backup/on-start.sh
+++ b/scripts/migrate-ebs-data-backup/on-start.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 set -e
+
+# OVERVIEW
+# This script creates a snapshot of EBS volume /home/ec2-user/SageMaker/ to a S3 bucket specified by tag on the notebook instance (ebs-backup-bucket). 
+#
+# The snapshot can be download into a new instance using https://github.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples/tree/master/scripts/migrate-ebs-data-sync/on-create.sh.
+# 
+# Note that the execution is done with nohup to bypass the startup timeout set by SageMaker Notebook instance. Depending on the size of the source /home/ec2-user/SageMaker/, it may take more than 5 minutes. You would see a text file BACKUP_COMPLETE created in /home/ec2-user/SageMaker/ and in the S3 bucket to denote the completion.
+#
+# Note if your notebook instance is in VPC mode without a direct internet access, please create a S3 VPC Gateway endpoint (https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-s3.html) and a SageMaker API VPC interface endpoint (https://docs.aws.amazon.com/sagemaker/latest/dg/interface-vpc-endpoint.html).
+#
+# See detail instruction in https://aws.amazon.com/blogs/machine-learning/xxxxx
+
 cat << "EOF" > /home/ec2-user/backup.sh
 #!/bin/bash
 NOTEBOOK_ARN=$(jq '.ResourceArn' /opt/ml/metadata/resource-metadata.json --raw-output)

--- a/scripts/migrate-ebs-data-sync/on-create.sh
+++ b/scripts/migrate-ebs-data-sync/on-create.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 set -e
+
+# OVERVIEW
+# This script downloads a snapshot specified by tags (ebs-backup-bucket and backup-snapshot)on the notebook instance into /home/ec2-user/SageMaker/. 
+# The snapshot can be created from an existing instace using https://github.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples/tree/master/scripts/migrate-ebs-data-backup/on-start.sh.
+# 
+# Note that the execution is done with nohup to bypass the startup timeout set by SageMaker Notebook instance. Depending on the size of the source /home/ec2-user/SageMaker/, it may take more than 5 minutes. You would see a text file SYNC_COMPLETE created in /home/ec2-user/SageMaker/ to denote the completion.
+#
+# Note if your notebook instance is in VPC mode without a direct internet access, please create a S3 VPC Gateway endpoint (https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-s3.html) and a SageMaker API VPC interface endpoint (https://docs.aws.amazon.com/sagemaker/latest/dg/interface-vpc-endpoint.html).
+#
+# See detail instruction in https://aws.amazon.com/blogs/machine-learning/xxxxx
+
 cat << "EOF" > /home/ec2-user/sync.sh
 # When creating a new AL2 notebook instance, sync from a snapshot in S3 bucket to /home/ec2-user/SageMaker/
 NOTEBOOK_ARN=$(jq '.ResourceArn' /opt/ml/metadata/resource-metadata.json --raw-output)

--- a/scripts/migrate-ebs-data-sync/on-create.sh
+++ b/scripts/migrate-ebs-data-sync/on-create.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+cat << "EOF" > /home/ec2-user/sync.sh
+# When creating a new AL2 notebook instance, sync from a snapshot in S3 bucket to /home/ec2-user/SageMaker/
+NOTEBOOK_ARN=$(jq '.ResourceArn' /opt/ml/metadata/resource-metadata.json --raw-output)
+NOTEBOOK_NAME=$(jq '.ResourceName' /opt/ml/metadata/resource-metadata.json --raw-output)
+VAR_BACKUP_SOURCE=ebs-backup-bucket
+BUCKET=$(aws sagemaker list-tags --resource-arn $NOTEBOOK_ARN  | jq -r --arg VAR_BACKUP_SOURCE "$VAR_BACKUP_SOURCE" .'Tags[] | select(.Key == $VAR_BACKUP_SOURCE).Value' --raw-output)
+VAR_SNAPSHOT=backup-snapshot
+SNAPSHOT=$(aws sagemaker list-tags --resource-arn $NOTEBOOK_ARN  | jq -r --arg VAR_SNAPSHOT "$VAR_SNAPSHOT" .'Tags[] | select(.Key == $VAR_SNAPSHOT).Value' --raw-output)
+
+# check if SNAPSHOT exists, if not, proceed without sync
+echo "Checking if s3://${BUCKET}/${SNAPSHOT} exists..."
+aws s3 ls s3://${BUCKET}/${SNAPSHOT} || (echo "Snapshot s3://${BUCKET}/${SNAPSHOT} does not exist. Proceed without the sync."; exit 0)
+echo "Sync-ing s3://${BUCKET}/${SNAPSHOT}/ to /home/ec2-user/SageMaker/"
+aws s3 sync s3://${BUCKET}/${SNAPSHOT}/ /home/ec2-user/SageMaker/ 
+exitcode=$?
+echo $exitcode
+if [ $exitcode -eq 0 ] || [ $exitcode -eq 2 ]
+then
+    TIMESTAMP=`date +%F-%H-%M-%S`
+    echo "Completed at $TIMESTAMP" > /home/ec2-user/SageMaker/SYNC_COMPLETE
+fi
+EOF
+
+chmod +x /home/ec2-user/sync.sh
+chown ec2-user:ec2-user /home/ec2-user/sync.sh
+
+# nohup to bypass the notebook instance timeout at start
+sudo -u ec2-user nohup /home/ec2-user/sync.sh >>  /home/ec2-user/nohup.out 2>&1 &
+ 

--- a/scripts/migrate-ebs-data-sync/on-create.sh
+++ b/scripts/migrate-ebs-data-sync/on-create.sh
@@ -5,8 +5,8 @@ set -e
 # This script downloads a snapshot specified by tags (ebs-backup-bucket and backup-snapshot)on the notebook instance into /home/ec2-user/SageMaker/. 
 # The snapshot can be created from an existing instace using https://github.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples/tree/master/scripts/migrate-ebs-data-backup/on-start.sh.
 # 
-# Note that the execution is done with nohup to bypass the startup timeout set by SageMaker Notebook instance. Depending on the size of the source /home/ec2-user/SageMaker/, it may take more than 5 minutes. You would see a text file SYNC_COMPLETE created in /home/ec2-user/SageMaker/ to denote the completion.
-#
+# Note that the execution is done with nohup to bypass the startup timeout set by SageMaker Notebook instance. Depending on the size of the source /home/ec2-user/SageMaker/, it may take more than 5 minutes. You would see a text file SYNC_COMPLETE created in /home/ec2-user/SageMaker/ to denote the completion. You need s3:GetObject, s3:PutObject, and s3:ListBucket for the S3 bucket in the execution role to perform aws s3 sync.
+# 
 # Note if your notebook instance is in VPC mode without a direct internet access, please create a S3 VPC Gateway endpoint (https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-s3.html) and a SageMaker API VPC interface endpoint (https://docs.aws.amazon.com/sagemaker/latest/dg/interface-vpc-endpoint.html).
 #
 # See detail instruction in https://aws.amazon.com/blogs/machine-learning/xxxxx


### PR DESCRIPTION
**Issue #, if available:**
None. This is to accompany an upcoming feature.

**Description of changes:**
This pair of scripts help create a backup of `/home/ec2-user/SageMaker/` from an existing instance and downloads it to a new instance. 

**Testing Done**

- [x] Notebook Instance created successfully with the Lifecycle Configuration
- [x] Notebook Instance stopped and started successfully
- [x] Documentation in the script around any network access requirements
- [x] Documentation in the script around any IAM permission requirements
- [x] CLI commands used to validate functionality on the instance
- [x] New script link and description added to README.md

```
# Provide your commands here
# scripts/migrate-ebs-data-backup/on-start.sh
cat << "EOF" > /home/ec2-user/backup.sh
#!/bin/bash
NOTEBOOK_ARN=$(jq '.ResourceArn' /opt/ml/metadata/resource-metadata.json --raw-output)
NOTEBOOK_NAME=$(jq '.ResourceName' /opt/ml/metadata/resource-metadata.json --raw-output)
BACKUP_DESTINATION=ebs-backup-bucket
BUCKET=$(aws sagemaker list-tags --resource-arn $NOTEBOOK_ARN  | jq -r --arg BACKUP_DESTINATION "$BACKUP_DESTINATION" .'Tags[] | select(.Key == $BACKUP_DESTINATION).Value' --raw-output)
# check if bucket exists
# if not, create a bucket
echo "Checking if s3://${BUCKET} exists..."
aws s3api wait bucket-exists --bucket $BUCKET || (echo "s3://${BUCKET} does not exist, creating..."; aws s3 mb s3://${BUCKET})
TIMESTAMP=`date +%F-%H-%M-%S`
SNAPSHOT=${NOTEBOOK_NAME}_${TIMESTAMP}
echo "Backup up /home/ec2-user/SageMaker/ to s3://${BUCKET}/${SNAPSHOT}/"
aws s3 sync --exclude "*/lost+found/*" /home/ec2-user/SageMaker/ s3://${BUCKET}/${SNAPSHOT}/
exitcode=$?
echo $exitcode
if [ $exitcode -eq 0 ] || [ $exitcode -eq 2 ]
then
    TIMESTAMP=`date +%F-%H-%M-%S`
    echo "Created s3://${BUCKET}/${SNAPSHOT}/" > /home/ec2-user/SageMaker/BACKUP_COMPLETE
    echo "Completed at $TIMESTAMP" >> /home/ec2-user/SageMaker/BACKUP_COMPLETE
    aws s3 cp /home/ec2-user/SageMaker/BACKUP_COMPLETE s3://${BUCKET}/${SNAPSHOT}/BACKUP_COMPLETE
fi
EOF

chmod +x /home/ec2-user/backup.sh
chown ec2-user:ec2-user /home/ec2-user/backup.sh

# nohup to bypass the notebook instance timeout at start
sudo -u ec2-user nohup /home/ec2-user/backup.sh >>  /home/ec2-user/nohup.out 2>&1 & 
```

```
# Provide your commands here
# scripts/migrate-ebs-data-sync/on-create.sh
cat << "EOF" > /home/ec2-user/sync.sh
# When creating a new AL2 notebook instance, sync from a snapshot in S3 bucket to /home/ec2-user/SageMaker/
NOTEBOOK_ARN=$(jq '.ResourceArn' /opt/ml/metadata/resource-metadata.json --raw-output)
NOTEBOOK_NAME=$(jq '.ResourceName' /opt/ml/metadata/resource-metadata.json --raw-output)
VAR_BACKUP_SOURCE=ebs-backup-bucket
BUCKET=$(aws sagemaker list-tags --resource-arn $NOTEBOOK_ARN  | jq -r --arg VAR_BACKUP_SOURCE "$VAR_BACKUP_SOURCE" .'Tags[] | select(.Key == $VAR_BACKUP_SOURCE).Value' --raw-output)
VAR_SNAPSHOT=backup-snapshot
SNAPSHOT=$(aws sagemaker list-tags --resource-arn $NOTEBOOK_ARN  | jq -r --arg VAR_SNAPSHOT "$VAR_SNAPSHOT" .'Tags[] | select(.Key == $VAR_SNAPSHOT).Value' --raw-output)

# check if SNAPSHOT exists, if not, proceed without sync
echo "Checking if s3://${BUCKET}/${SNAPSHOT} exists..."
aws s3 ls s3://${BUCKET}/${SNAPSHOT} || (echo "Snapshot s3://${BUCKET}/${SNAPSHOT} does not exist. Proceed without the sync."; exit 0)
echo "Sync-ing s3://${BUCKET}/${SNAPSHOT}/ to /home/ec2-user/SageMaker/"
aws s3 sync s3://${BUCKET}/${SNAPSHOT}/ /home/ec2-user/SageMaker/ 
exitcode=$?
echo $exitcode
if [ $exitcode -eq 0 ] || [ $exitcode -eq 2 ]
then
    TIMESTAMP=`date +%F-%H-%M-%S`
    echo "Completed at $TIMESTAMP" > /home/ec2-user/SageMaker/SYNC_COMPLETE
fi
EOF

chmod +x /home/ec2-user/sync.sh
chown ec2-user:ec2-user /home/ec2-user/sync.sh

# nohup to bypass the notebook instance timeout at start
sudo -u ec2-user nohup /home/ec2-user/sync.sh >>  /home/ec2-user/nohup.out 2>&1 &
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
