### PR TITLE
Bug fixed when adding multiple custom conda envs in Jupyter

### DIFF
--- a/scripts/persistent-conda-ebs/on-start.sh
+++ b/scripts/persistent-conda-ebs/on-start.sh
@@ -22,6 +22,7 @@ for env in $WORKING_DIR/miniconda/envs/*; do
     BASENAME=$(basename "$env")
     source activate "$BASENAME"
     python -m ipykernel install --user --name "$BASENAME" --display-name "Custom ($BASENAME)"
+    conda deactivate
 done
 
 # Optionally, uncomment these lines to disable SageMaker-provided Conda functionality.


### PR DESCRIPTION


**Issue #, if available:**

**Description of changes:**

Deactivating custom Conda env added in the loop when adding each custom env as a kernel in Jupyter.

More details:
I think each env should be deactivated after being added as a  kernel in Jupyter.
The previous version causes the following error for me when I have multiple custom Conda environments. Just the first custom Conda environment in the loop is added correctly. Note that all custom Conda environments will appear on Jupyter, but not all of them work correctly.
The error in terminal:
Could not find Conda environment: "name_of_the_custom_conda_env"

**Testing Done**


- **_Done_** Notebook Instance created successfully with the Lifecycle Configuration
- **_Done_** Notebook Instance stopped and started successfully
- [ ] Documentation in the script around any network access requirements
- [ ] Documentation in the script around any IAM permission requirements
- [ ] CLI commands used to validate functionality on the instance
- [ ] New script link and description added to README.md

```
# Provide your commands here
/you/commands/here
```





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
