### PR TITLE
Fix autostop.py's execution state bug

### DIFF
--- a/scripts/auto-stop-idle/autostop.py
+++ b/scripts/auto-stop-idle/autostop.py
@@ -91,7 +91,7 @@ if len(data) > 0:
     for notebook in data:
         # Idleness is defined by Jupyter
         # https://github.com/jupyter/notebook/issues/4634
-        if notebook['kernel']['execution_state'] == 'idle':
+        if notebook['kernel']['execution_state'] != 'busy':
             if not ignore_connections:
                 if notebook['kernel']['connections'] == 0:
                     if not is_idle(notebook['kernel']['last_activity']):


### PR DESCRIPTION
**Issue #, if available:**
We've observed that sometimes notebooks/consoles getting stuck in 'starting' state. 

**Description of changes:**
Passing only when execution state is busy will make this code work properly.

**Testing Done**

- [ ] Notebook Instance created successfully with the Lifecycle Configuration
- [ ] Notebook Instance stopped and started successfully
- [ ] Documentation in the script around any network access requirements
- [ ] Documentation in the script around any IAM permission requirements
- [ ] CLI commands used to validate functionality on the instance
- [ ] New script link and description added to README.md

```
# Provide your commands here
/you/commands/here
```





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
