### PR TITLE
Update execute notebook on startup script

### DIFF
--- a/scripts/execute-notebook-on-startup/on-start.sh
+++ b/scripts/execute-notebook-on-startup/on-start.sh
@@ -7,11 +7,11 @@ set -e
 
 # PARAMETERS
 
-ENVIRONMENT=pytorch_p36
+ENVIRONMENT=pytorch_p37
 NOTEBOOK_FILE=/home/ec2-user/SageMaker/MyNotebook.ipynb
 
 source /home/ec2-user/anaconda3/bin/activate "$ENVIRONMENT"
 
-jupyter nbconvert "$NOTEBOOK_FILE" --ExecutePreprocessor.kernel_name=python --execute
+jupyter nbconvert "$NOTEBOOK_FILE" --ExecutePreprocessor.kernel_name=python --execute --to notebook
 
 source /home/ec2-user/anaconda3/bin/deactivate


### PR DESCRIPTION
- Current SageMaker Notebook instance does not have `pytorch_p36`. It's `pytorch_p37` now. 
- The current `nbconvert` version requires explicit `--to` parameter.

**Issue #, if available:**
The script is not working, and needs some modification.

**Description of changes:**
Few modification to make the lifecycle configuration script work on the current SageMaker Notebook instance.
- Current SageMaker Notebook instance does not have `pytorch_p36`. It's `pytorch_p37` now. 
- The current `nbconvert` version requires explicit `--to` parameter.

**Testing Done**

- [x] Notebook Instance created successfully with the Lifecycle Configuration
- [x] Notebook Instance stopped and started successfully
- [ ] Documentation in the script around any network access requirements
- [ ] Documentation in the script around any IAM permission requirements
- [ ] CLI commands used to validate functionality on the instance
- [ ] New script link and description added to README.md

```
# Provide your commands here
/you/commands/here
```





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
