### PR TITLE
Jupyter server "restart" command update for Amazon Linux 2

### DIFF
--- a/scripts/persistent-conda-ebs/on-start.sh
+++ b/scripts/persistent-conda-ebs/on-start.sh
@@ -29,8 +29,12 @@ done
 # rm /home/ec2-user/.condarc
 EOF
 
+# For Amazon Linux 1 ("notebook-al1-v1" platform identifier):
 echo "Restarting the Jupyter server.."
 restart jupyter-server
 
-# For "notebook-al2-v1" platform identifier use command below to restart server:
-#sudo systemctl restart jupyter-server
+# For Amazon Linux 2 ("notebook-al2-v1" platform identifier):
+# echo "Restarting the Jupyter server.."
+# systemctl restart jupyter-server
+# echo "Status of Jupyter server.."
+# systemctl status jupyter-server

--- a/scripts/persistent-conda-ebs/on-start.sh
+++ b/scripts/persistent-conda-ebs/on-start.sh
@@ -30,4 +30,4 @@ done
 EOF
 
 echo "Restarting the Jupyter server.."
-restart jupyter-server
+sudo systemctl restart jupyter-server

--- a/scripts/persistent-conda-ebs/on-start.sh
+++ b/scripts/persistent-conda-ebs/on-start.sh
@@ -30,4 +30,7 @@ done
 EOF
 
 echo "Restarting the Jupyter server.."
-sudo systemctl restart jupyter-server
+restart jupyter-server
+
+# For "notebook-al2-v1" platform identifier use command below to restart server:
+#sudo systemctl restart jupyter-server


### PR DESCRIPTION
**Issue #, if available:**
"restart jupyter-server" does not seem to work on Amazon Linux 2 Operating Systems due to a "restart: command not found" error

**Description of changes:**
Added option for a new command "systemctl restart jupyter-server" to be used for Amazon Linux 2 Operating Systems and  "systemctl status jupyter-server" command for feedback/verbosity

**Testing Done**

- [x] Notebook Instance created successfully with the Lifecycle Configuration
- [x] Notebook Instance stopped and started successfully
- [ ] Documentation in the script around any network access requirements
- [ ] Documentation in the script around any IAM permission requirements
- [ ] CLI commands used to validate functionality on the instance
- [ ] New script link and description added to README.md

```
# Provide your commands here
/you/commands/here
```





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
