### PR TITLE
Adjusted script to work for both Amazon Linux 1 and Amazon Linux 2 notebook …

### DIFF
--- a/scripts/auto-stop-idle/on-start.sh
+++ b/scripts/auto-stop-idle/on-start.sh
@@ -21,4 +21,4 @@ wget https://raw.githubusercontent.com/aws-samples/amazon-sagemaker-notebook-ins
 
 echo "Starting the SageMaker autostop script in cron"
 
-(crontab -l 2>/dev/null; echo "*/5 * * * * /usr/bin/python $PWD/autostop.py --time $IDLE_TIME --ignore-connections") | crontab -
+(crontab -l 2>/dev/null; echo "*/5 * * * * /usr/bin/python3 $PWD/autostop.py --time $IDLE_TIME --ignore-connections") | crontab -

--- a/scripts/auto-stop-idle/on-start.sh
+++ b/scripts/auto-stop-idle/on-start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 # OVERVIEW
 # This script stops a SageMaker notebook once it's idle for more than 1 hour (default time)

--- a/scripts/auto-stop-idle/on-start.sh
+++ b/scripts/auto-stop-idle/on-start.sh
@@ -21,4 +21,6 @@ wget https://raw.githubusercontent.com/aws-samples/amazon-sagemaker-notebook-ins
 
 echo "Starting the SageMaker autostop script in cron"
 
-(crontab -l 2>/dev/null; echo "*/5 * * * * /usr/bin/python3 $PWD/autostop.py --time $IDLE_TIME --ignore-connections") | crontab -
+
+# Create cron expression and redirect output to /var/log/jupyter.log so it is viewable in CloudWatch
+(crontab -l 2>/dev/null; echo "*/5 * * * * /usr/bin/python3 $PWD/autostop.py --time $IDLE_TIME --ignore-connections >> /var/log/jupyter.log") | crontab -

--- a/scripts/auto-stop-idle/on-start.sh
+++ b/scripts/auto-stop-idle/on-start.sh
@@ -14,7 +14,7 @@ set -ex
 #
 
 # PARAMETERS
-IDLE_TIME=900
+IDLE_TIME=3600
 
 echo "Fetching the autostop script"
 wget https://raw.githubusercontent.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples/master/scripts/auto-stop-idle/autostop.py


### PR DESCRIPTION
**Issue #, if available:**
[82](https://github.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples/issues/82)

**Description of changes:**
x flag added to the set command to increase verbosity in logs.

Script will test importing boto3 from `/usr/bin/python` which is successful for Amazon Linux 1 notebooks but fails for Amazon Linux 2 currently. If it fails (as expected on Amazon Linux 2) it will try again with `/usr/bin/python3` (which has boto3 installed for both Amazon Linux 1 and Amazon Linux 2). If that fails it will exit with error. The cron task is set to use whichever is successful.

Python output from cron redirected to `/var/log/jupyter.log`. This makes the output from the script viewable in CloudWatch logs for the instance allowing for easier debugging.

**Testing Done**

- [x] Notebook Instance created successfully with the Lifecycle Configuration
- [x] Notebook Instance stopped and started successfully
- [ ] Documentation in the script around any network access requirements
- [ ] Documentation in the script around any IAM permission requirements
- [x] CLI commands used to validate functionality on the instance
- [ ] New script link and description added to README.md

```
# On Amazon Linux 1 notebook
/usr/bin/python -c "import boto3"
/usr/bin/python3 -c "import boto3"

# On Amazon Linux 2 notebook
/usr/bin/python -c "import boto3"
/usr/bin/python3 -c "import boto3"
```





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
