### PR TITLE
Append metrics configurations to existing logging configurations

### DIFF
--- a/scripts/publish-instance-metrics/on-start.sh
+++ b/scripts/publish-instance-metrics/on-start.sh
@@ -22,6 +22,9 @@ sed -i -- "s/MyNotebookInstance/$NOTEBOOK_INSTANCE_NAME/g" amazon-cloudwatch-age
 
 echo "Starting the CloudWatch agent on the Notebook Instance."
 /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a \
-    fetch-config -m ec2 -c file://$(pwd)/amazon-cloudwatch-agent.json -s
+    append-config -m ec2 -c file://$(pwd)/amazon-cloudwatch-agent.json
+
+restart restart-cloudwatch-agent || true 
+systemctl restart amazon-cloudwatch-agent.service || true
 
 rm amazon-cloudwatch-agent.json


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This change is to fix issue where customers are not seeing logs after running this LCC. Previously with
AL1, there were two cloudwatch instances running where the old process had old logging configs and
was publishing logs, while the newer process had the metrics configs and was publishing metrics.
For AL2 instead of starting a second process, it is actually restarting the old process, which results
in that new process only having metrics configs and not having any logging configs. As a result no
logs are emitted. This change will append the new configs so the process can publish both the logs
and the metrics.

**Testing Done**

- [X] Notebook Instance created successfully with the Lifecycle Configuration
- [X] Notebook Instance stopped and started successfully
- [ ] Documentation in the script around any network access requirements
- [ ] Documentation in the script around any IAM permission requirements
- [ ] CLI commands used to validate functionality on the instance
- [ ] New script link and description added to README.md

```
# Provide your commands here
/you/commands/here
```





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
