### PR TITLE
Auto stop print logging to catch idle state setting

### DIFF
--- a/scripts/auto-stop-idle/autostop.py
+++ b/scripts/auto-stop-idle/autostop.py
@@ -98,11 +98,11 @@ if len(data) > 0:
                         idle = False
                 else:
                     idle = False
-                    print('Notebook idle state set ', idle, ' due to kernel connections.')
+                    print(f'Notebook idle state set as {idle} because no kernel has been detected.')
             else:
                 if not is_idle(notebook['kernel']['last_activity']):
                     idle = False
-                    print('Notebook idle state set ', idle, ' since connections are ignored.')
+                    print(f'Notebook idle state set as {idle} since kernel connections are ignored.')
         else:
             print('Notebook is not idle:', notebook['kernel']['execution_state'])
             idle = False
@@ -113,7 +113,7 @@ else:
     )['LastModifiedTime']
     if not is_idle(uptime.strftime("%Y-%m-%dT%H:%M:%S.%fz")):
         idle = False
-        print('Notebook idle state set ', idle, 'since no sessions detected.')
+        print(f'Notebook idle state set as {idle} since no sessions detected.')
 
 if idle:
     print('Closing idle notebook')

--- a/scripts/auto-stop-idle/autostop.py
+++ b/scripts/auto-stop-idle/autostop.py
@@ -96,7 +96,7 @@ if len(data) > 0:
                 if notebook['kernel']['connections'] == 0:
                     if not is_idle(notebook['kernel']['last_activity']):
                         idle = False
-                        print('Notebook idle state is now: ',idle)
+                        print('Notebook idle state is now: ', idle)
                 else:
                     idle = False
                     print('Notebook idle state is now: ', idle)

--- a/scripts/auto-stop-idle/autostop.py
+++ b/scripts/auto-stop-idle/autostop.py
@@ -96,14 +96,18 @@ if len(data) > 0:
                 if notebook['kernel']['connections'] == 0:
                     if not is_idle(notebook['kernel']['last_activity']):
                         idle = False
+                        print('Notebook idle state is now: ',idle)
                 else:
                     idle = False
+                    print('Notebook idle state is now: ', idle)
             else:
                 if not is_idle(notebook['kernel']['last_activity']):
                     idle = False
+                    print('Notebook idle state is now: ', idle)
         else:
             print('Notebook is not idle:', notebook['kernel']['execution_state'])
             idle = False
+            print('Notebook idle state is now: ', idle)
 else:
     client = boto3.client('sagemaker')
     uptime = client.describe_notebook_instance(
@@ -111,6 +115,7 @@ else:
     )['LastModifiedTime']
     if not is_idle(uptime.strftime("%Y-%m-%dT%H:%M:%S.%fz")):
         idle = False
+        print('Notebook idle state is now: ', idle)
 
 if idle:
     print('Closing idle notebook')

--- a/scripts/auto-stop-idle/autostop.py
+++ b/scripts/auto-stop-idle/autostop.py
@@ -96,18 +96,16 @@ if len(data) > 0:
                 if notebook['kernel']['connections'] == 0:
                     if not is_idle(notebook['kernel']['last_activity']):
                         idle = False
-                        print('Notebook idle state is now: ', idle)
                 else:
                     idle = False
-                    print('Notebook idle state is now: ', idle)
+                    print('Notebook idle state set ', idle, ' due to kernel connections.')
             else:
                 if not is_idle(notebook['kernel']['last_activity']):
                     idle = False
-                    print('Notebook idle state is now: ', idle)
+                    print('Notebook idle state set ', idle, ' since connections are ignored.')
         else:
             print('Notebook is not idle:', notebook['kernel']['execution_state'])
             idle = False
-            print('Notebook idle state is now: ', idle)
 else:
     client = boto3.client('sagemaker')
     uptime = client.describe_notebook_instance(
@@ -115,7 +113,7 @@ else:
     )['LastModifiedTime']
     if not is_idle(uptime.strftime("%Y-%m-%dT%H:%M:%S.%fz")):
         idle = False
-        print('Notebook idle state is now: ', idle)
+        print('Notebook idle state set ', idle, 'since no sessions detected.')
 
 if idle:
     print('Closing idle notebook')


### PR DESCRIPTION
**Issue #, if available:**
(https://t.corp.amazon.com/V746619799/overview)

**Description of changes:**
print statements added to catch idle state settings in auto-stop-idle LCC python script autostop.py. 

**Testing Done**
- [x] No change in LCC functionality
- [x] Notebook Instance created successfully with the Lifecycle Configuration
- [x] Modified script executed successfully within notebook instance
- [ ] Notebook Instance stopped and started successfully
- [ ] Documentation in the script around any network access requirements
- [ ] Documentation in the script around any IAM permission requirements
- [ ] CLI commands used to validate functionality on the instance
- [ ] New script link and description added to README.md

Note:
Failure replication unsuccessful. Notebook instance successfully auto stops after I ran a 10 second auto stop cron within the instance. Cloud watch log aligns with auto stop behavior and no idle deactivation is logged.

```
# Provide your commands here
/you/commands/here
```





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
