### PR TITLE
Added logic to determine system restart based on AL and JL versions.

### DIFF
--- a/scripts/set-env-variable/on-start.sh
+++ b/scripts/set-env-variable/on-start.sh
@@ -9,11 +9,24 @@ set -e
 #   1. Ensure the Notebook Instance execution role has permission of SageMaker:ListTags
 #
 
+#sudo -u ec2-user -i <<'EOF'
+
 # PARAMETERS
-YOUR_ENV_VARIABLE_NAME=your_env_variable_name
+YOUR_ENV_VARIABLE_NAME=<ENV_VAR_NAME>
 
 NOTEBOOK_ARN=$(jq '.ResourceArn' /opt/ml/metadata/resource-metadata.json --raw-output)
 TAG=$(aws sagemaker list-tags --resource-arn $NOTEBOOK_ARN  | jq -r --arg YOUR_ENV_VARIABLE_NAME "$YOUR_ENV_VARIABLE_NAME" .'Tags[] | select(.Key == $YOUR_ENV_VARIABLE_NAME).Value' --raw-output)
 touch /etc/profile.d/jupyter-env.sh
 echo "export $YOUR_ENV_VARIABLE_NAME=$TAG" >> /etc/profile.d/jupyter-env.sh
-initctl restart jupyter-server --no-wait
+
+# restart command is dependent on current running Amazon Linux and JupyterLab
+CURR_VERSION_AL=$(cat /etc/system-release)
+CURR_VERSION_JS=$(jupyter --version)
+
+if [[ $CURR_VERSION_JS == *$"jupyter_core     : 4.9.1"* ]] && [[ $CURR_VERSION_AL == *$" release 2018"* ]]; then
+	sudo initctl restart jupyter-server --no-wait
+else
+	sudo systemctl --no-block restart jupyter-server.service || true
+fi
+
+#EOF


### PR DESCRIPTION
**Issue #, if available:**
https://sim.amazon.com/issues/MD-10193
sub-issue created for issue - https://sim.amazon.com/issues/MD-10308

**Description of changes:**
We have two Amazon Linux and Jupyter Lab versions available for notebook instance creations.  This code change determines which command to execute for system restart based on the current AL/JL version.

**Testing Done**
Executed on personal notebook instances with AL/JL version combinations.

- [x] Notebook Instance created successfully with the Lifecycle Configuration
- [x] Notebook Instance stopped and started successfully
- [ ] Documentation in the script around any network access requirements
- [ ] Documentation in the script around any IAM permission requirements
- [ ] CLI commands used to validate functionality on the instance
- [ ] New script link and description added to README.md

```
# Provide your commands here
/you/commands/here
```





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
