### PR TITLE
Added logic to determine lustre install based on AL/JL version. Removed error squash.

### DIFF
--- a/scripts/mount-fsx-lustre-file-system/on-start.sh
+++ b/scripts/mount-fsx-lustre-file-system/on-start.sh
@@ -10,20 +10,34 @@ set -e
 #   1. There's an FSx for Lustre file system created and running
 #   2. The FSx for Lustre file system is accessible from the Notebook Instance
 #       - The Notebook Instance has to be created on the same VPN as the FSx for Lustre file system
-#       - The subnets and security groups have to be properly set up
+#       - The subnets and security groups have to be properly set up.  Same values for file system and notebook.
 #   3. Set the FSX_DNS_NAME parameter below to the DNS name of the FSx for Lustre file system.
-#   4. Set the FSX_MOUNT_NAME parameter below to the Mount name of the FSx for Lustre file system.
+#   4. Set the FSX_MOUNT_NAME parameter below to the Mount name of the FSx for Lustre file system. It's not the name you appointed at creation.
+
+
+#sudo -u ec2-user -i <<'EOF'
 
 # PARAMETERS
 FSX_DNS_NAME=fs-your-fs-id.fsx.your-region.amazonaws.com
 FSX_MOUNT_NAME=your-mount-name
 
-# First, we need to install the lustre-client libraries
-sudo yum install -y lustre-client
+# First, we need to install the lustre libraries
+# this command is dependent on current running Amazon Linux and JupyterLab versions
+CURR_VERSION_AL=$(cat /etc/system-release)
+CURR_VERSION_JS=$(jupyter --version)
+
+if [[ $CURR_VERSION_JS == *$"jupyter_core     : 4.9.1"* ]] && [[ $CURR_VERSION_AL == *$" release 2018"* ]]; then
+	sudo yum install -y lustre-client
+else
+	sudo amazon-linux-extras install -y lustre
+fi
 
 # Now we can create the mount point and mount the file system
-sudo mkdir /fsx
+sudo mkdir -p /fsx
+
 sudo mount -t lustre -o noatime,flock $FSX_DNS_NAME@tcp:/$FSX_MOUNT_NAME /fsx
 
 # Let's make sure we have the appropriate access to the directory
 sudo chmod go+rw /fsx
+
+#EOF

--- a/scripts/set-env-variable/on-start.sh
+++ b/scripts/set-env-variable/on-start.sh
@@ -26,7 +26,7 @@ CURR_VERSION_JS=$(jupyter --version)
 if [[ $CURR_VERSION_JS == *$"jupyter_core     : 4.9.1"* ]] && [[ $CURR_VERSION_AL == *$" release 2018"* ]]; then
 	sudo initctl restart jupyter-server --no-wait
 else
-	sudo systemctl --no-block restart jupyter-server.service || true
+	sudo systemctl --no-block restart jupyter-server.service
 fi
 
 #EOF


### PR DESCRIPTION
**Issue #, if available:**
https://sim.amazon.com/issues/MD-10193
sub-issue created for issue - https://sim.amazon.com/issues/MD-10311

**Description of changes:**
We have two Amazon Linux and Jupyter Lab versions available for notebook instance creations. This code change determines which command to execute for lustre installation based on the current AL/JL version.

**Testing Done**
Deployed to personal notebook instances with various AL and JL version combinations.

- [x] Notebook Instance created successfully with the Lifecycle Configuration
- [x] Notebook Instance stopped and started successfully
- [ ] Documentation in the script around any network access requirements
- [ ] Documentation in the script around any IAM permission requirements
- [ ] CLI commands used to validate functionality on the instance
- [ ] New script link and description added to README.md

```
# Provide your commands here
/you/commands/here
```





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
