### PR TITLE
Revert "Auto stop print logging to catch idle state setting"

### DIFF
--- a/scripts/auto-stop-idle/autostop.py
+++ b/scripts/auto-stop-idle/autostop.py
@@ -98,11 +98,9 @@ if len(data) > 0:
                         idle = False
                 else:
                     idle = False
-                    print(f'Notebook idle state set as {idle} because no kernel has been detected.')
             else:
                 if not is_idle(notebook['kernel']['last_activity']):
                     idle = False
-                    print(f'Notebook idle state set as {idle} since kernel connections are ignored.')
         else:
             print('Notebook is not idle:', notebook['kernel']['execution_state'])
             idle = False
@@ -113,7 +111,6 @@ else:
     )['LastModifiedTime']
     if not is_idle(uptime.strftime("%Y-%m-%dT%H:%M:%S.%fz")):
         idle = False
-        print(f'Notebook idle state set as {idle} since no sessions detected.')
 
 if idle:
     print('Closing idle notebook')


### PR DESCRIPTION
Reverts aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples#95

These print statements break the [auto-stop-idle](https://github.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples/commits/master/scripts/auto-stop-idle) LCC script when using SageMaker Notebook instance al1-v1 platform.
Platform al1-v1 uses Python 2.7 to execute the autostop.py script, however f-strings formatting is supportd from Python 3.6. [[1]](https://peps.python.org/pep-0498/)

Specifically, using al1-v1 platform the script execution fails with following error:
```
  File "//autostop.py", line 101
    print(f'Notebook idle state set as {idle} because no kernel has been detected.')
                                                                                  ^
SyntaxError: invalid syntax
```
Please revert these changes as this can cause unwanted charges for users that rely on the auto-stop LCC to Stop idle NB instances that uses al1-v1 platform.

See open issue: https://github.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples/issues/100