### PR TITLE
logic for restart command to work on AL1 and AL2 platforms.

### DIFF
--- a/scripts/persistent-conda-ebs/on-start.sh
+++ b/scripts/persistent-conda-ebs/on-start.sh
@@ -30,4 +30,12 @@ done
 EOF
 
 echo "Restarting the Jupyter server.."
-restart jupyter-server
+# restart command is dependent on current running Amazon Linux and JupyterLab
+CURR_VERSION_AL=$(cat /etc/system-release)
+CURR_VERSION_JS=$(jupyter --version)
+
+if [[ $CURR_VERSION_JS == *$"jupyter_core     : 4.9.1"* ]] && [[ $CURR_VERSION_AL == *$" release 2018"* ]]; then
+	sudo initctl restart jupyter-server --no-wait
+else
+	sudo systemctl --no-block restart jupyter-server.service
+fi


### PR DESCRIPTION
**Issue #, if available:**
https://issues.amazon.com/issues/MD-10312

**Description of changes:**
Added logic for restart command after conda ebs creation to be determined by running platform. 

**Testing Done**
LCC tested on legacy AL1v1 and new AL2v2 notebooks. 

Loaded current LCC and observed failure error:  ``` /tmp/OnStart_2022-11-17-19-092nflww27: line 33: restart: command not found ``` on AL2 notebook. AL1 was successful.

After inserting fix both notebooks are successful.

- [x] Notebook Instance created successfully with the Lifecycle Configuration
- [x] Notebook Instance stopped and started successfully
- [ ] Documentation in the script around any network access requirements
- [ ] Documentation in the script around any IAM permission requirements
- [x] CLI commands used to validate functionality on the instance
- [ ] New script link and description added to README.md

```
# Provide your commands here
/your/commands/here
```





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
