### PR TITLE
Fixing search for boto3 python version

### DIFF
--- a/scripts/auto-stop-idle/on-start.sh
+++ b/scripts/auto-stop-idle/on-start.sh
@@ -24,10 +24,10 @@ echo "Detecting Python install with boto3 install"
 
 # Find which install has boto3 and use that to run the cron command. So will use default when available
 # Redirect stderr as it is unneeded
-if /usr/bin/python3 -c "import boto3" 2>/dev/null; then
+if /usr/bin/python3.8 -c "import boto3" 2>/dev/null; then
+    PYTHON_DIR='/usr/bin/python3.8'
+elif /usr/bin/python3 -c "import boto3" 2>/dev/null; then
     PYTHON_DIR='/usr/bin/python3'
-elif /usr/bin/python -c "import boto3" 2>/dev/null; then
-    PYTHON_DIR='/usr/bin/python'
 else
     # If no boto3 just quit because the script won't work
     echo "No boto3 found in Python or Python3. Exiting..."


### PR DESCRIPTION
**Issue #, if available:**

Internal customer ticket - https://t.corp.amazon.com/V839050183/overview

**Description of changes:**

Ami update in region breaks search for python version capable of boto3 import.

```
sh-4.2$ ls | grep python
python
python2
python2.7
python2.7-config
python2-config
python3
python3.7
python3.7m
python3.8
python3.8-config
python3.8-x86_64-config
python-config

sh-4.2$ /usr/bin/python3 --version
Python 3.7.16

sh-4.2$ /usr/bin/python3
Python 3.7.16 (default, Dec 15 2022, 23:24:54)
[GCC 7.3.1 20180712 (Red Hat 7.3.1-15)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import boto3
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'boto3'
>>>
```


**Testing Done**

- [ ] Notebook Instance created successfully with the Lifecycle Configuration
- [ ] Notebook Instance stopped and started successfully
- [ ] Documentation in the script around any network access requirements
- [ ] Documentation in the script around any IAM permission requirements
- [x] CLI commands used to validate functionality on the instance
- [ ] New script link and description added to README.md

```
# Provide your commands here

sh-4.2$ if /usr/bin/python3.8 -c "import boto3" 2>/dev/null; then
> echo True
> fi
True
sh-4.2$

```





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
