### PR TITLE
Using conda python for boto3 install.

### DIFF
--- a/scripts/auto-stop-idle/on-start.sh
+++ b/scripts/auto-stop-idle/on-start.sh
@@ -24,8 +24,8 @@ echo "Detecting Python install with boto3 install"
 
 # Find which install has boto3 and use that to run the cron command. So will use default when available
 # Redirect stderr as it is unneeded
-if $(which python) -c "import boto3" 2>/dev/null; then
-    PYTHON_DIR=$(which python)
+if /usr/bin/python3.8 -c "import boto3" 2>/dev/null; then
+    PYTHON_DIR=/usr/bin/python3.8
 elif /usr/bin/python -c "import boto3" 2>/dev/null; then
     PYTHON_DIR='/usr/bin/python'
 else

--- a/scripts/auto-stop-idle/on-start.sh
+++ b/scripts/auto-stop-idle/on-start.sh
@@ -24,8 +24,9 @@ echo "Detecting Python install with boto3 install"
 
 # Find which install has boto3 and use that to run the cron command. So will use default when available
 # Redirect stderr as it is unneeded
-if /usr/bin/python3.8 -c "import boto3" 2>/dev/null; then
-    PYTHON_DIR=/usr/bin/python3.8
+CONDA_PYTHON_DIR=$(source /home/ec2-user/anaconda3/bin/activate /home/ec2-user/anaconda3/envs/JupyterSystemEnv && which python)
+if $CONDA_PYTHON_DIR -c "import boto3" 2>/dev/null; then
+    PYTHON_DIR=$CONDA_PYTHON_DIR
 elif /usr/bin/python -c "import boto3" 2>/dev/null; then
     PYTHON_DIR='/usr/bin/python'
 else


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Python3 in bin and Jupyter system Python on start do not support boto3 import. Need to dictate appropriate version to use for LCC. 

```
LCC load error:



+ /usr/bin/python -c 'import boto3'
--


<br class="Apple-interchange-newline">

2023-02-22T17:57:43.678-06:00CopyNo boto3 found in Python or Python3. Exiting... | No boto3 found in Python or Python3. Exiting...
-- | --


Jupyter environment version testing:

sh-4.2$ ls | grep python
python
python2
python2.7
python2.7-config
python2-config
python3
python3.7
python3.7m
python3.8
python3.8-config
python3.8-x86_64-config
python-config

sh-4.2$ /usr/bin/python3 --version
Python 3.7.16

sh-4.2$ /usr/bin/python3
Python 3.7.16 (default, Dec 15 2022, 23:24:54)
[GCC 7.3.1 20180712 (Red Hat 7.3.1-15)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import boto3
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'boto3'
>>>
```

**Testing Done**

LCC created and tested on both al2v1 and al2v2 notebooks in us-east-1. startup successful. stops successfully after 2mins(set time).

- [x] Notebook Instance created successfully with the Lifecycle Configuration
- [ ] Notebook Instance stopped and started successfully
- [ ] Documentation in the script around any network access requirements
- [ ] Documentation in the script around any IAM permission requirements
- [x] CLI commands used to validate functionality on the instance
- [ ] New script link and description added to README.md

```

Environment test:

sh-4.2$ CONDA_PYTHON_DIR=$(source /home/ec2-user/anaconda3/bin/activate /home/ec2-user/anaconda3/envs/JupyterSystemEnv && which python)
sh-4.2$ if $CONDA_PYTHON_DIR -c "import boto3" 2>/dev/null; then
> echo True
> fi
True
sh-4.2$ 

```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
