### PR TITLE
Updated determination tag for AL1 platform to use website.

### DIFF
--- a/scripts/mount-fsx-lustre-file-system/on-start.sh
+++ b/scripts/mount-fsx-lustre-file-system/on-start.sh
@@ -23,10 +23,8 @@ FSX_MOUNT_NAME=your-mount-name
 
 # First, we need to install the lustre libraries
 # this command is dependent on current running Amazon Linux and JupyterLab versions
-CURR_VERSION_AL=$(cat /etc/system-release)
-CURR_VERSION_JS=$(jupyter --version)
-
-if [[ $CURR_VERSION_JS == *$"jupyter_core     : 4.9.1"* ]] && [[ $CURR_VERSION_AL == *$" release 2018"* ]]; then
+CURR_VERSION=$(cat /etc/os-release)
+if [[ $CURR_VERSION == *$"http://aws.amazon.com/amazon-linux-ami/"* ]]; then
 	sudo yum install -y lustre-client
 else
 	sudo amazon-linux-extras install -y lustre


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
Current method of determining platform version is weak and prone to failure if AL1 ami packages get updated. This method searches for the more static AL1 site (https://aws.amazon.com/amazon-linux-ami/) string to determine appropriate command.

**Testing Done**

- [x] Notebook Instance created successfully with the Lifecycle Configuration
- [x] Notebook Instance stopped and started successfully
- [ ] Documentation in the script around any network access requirements
- [ ] Documentation in the script around any IAM permission requirements
- [x] CLI commands used to validate functionality on the instance
- [ ] New script link and description added to README.md

```
evidence of fsx mount creation in jupyter terminal:

sh-4.2$ cd /fsx/
sh-4.2$ 
```





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
