### PR TITLE
#90 check notebook and terminal sessions

### DIFF
--- a/scripts/auto-stop-idle/autostop.py
+++ b/scripts/auto-stop-idle/autostop.py
@@ -138,7 +138,6 @@ response = requests.get(
     verify=False,
 )
 data = response.json()
-print(data)
 idle = idle or is_terminal_state(data)
 
 if idle:

--- a/scripts/auto-stop-idle/autostop.py
+++ b/scripts/auto-stop-idle/autostop.py
@@ -134,7 +134,7 @@ else:
 
 # Check terminals is idle or not
 response = requests.get(
-    f"https://localhost:{port}//terminals",
+    f"https://localhost:{port}/api/terminals",
     verify=False,
 )
 data = response.json()

--- a/scripts/auto-stop-idle/autostop.py
+++ b/scripts/auto-stop-idle/autostop.py
@@ -138,7 +138,7 @@ response = requests.get(
     verify=False,
 )
 data = response.json()
-idle = idle or is_terminal_state(data)
+idle = idle and is_terminal_state(data)
 
 if idle:
     print("Closing idle notebook")

--- a/scripts/auto-stop-idle/autostop.py
+++ b/scripts/auto-stop-idle/autostop.py
@@ -137,7 +137,8 @@ response = requests.get(
     f"https://localhost:{port}//terminals",
     verify=False,
 )
-print(response)
+data = response.json()
+print(data)
 idle = idle or is_terminal_state(data)
 
 if idle:

--- a/scripts/auto-stop-idle/autostop.py
+++ b/scripts/auto-stop-idle/autostop.py
@@ -11,12 +11,14 @@
 #     express or implied. See the License for the specific language governing
 #     permissions and limitations under the License.
 
-import requests
-from datetime import datetime
-import getopt, sys
-import urllib3
-import boto3
+import getopt
 import json
+import sys
+from datetime import datetime
+
+import boto3
+import requests
+import urllib3
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -39,10 +41,12 @@ helpInfo = """-t, --time
 
 # Read in command-line parameters
 idle = True
-port = '8443'
+port = "8443"
 ignore_connections = False
 try:
-    opts, args = getopt.getopt(sys.argv[1:], "ht:p:c", ["help","time=","port=","ignore-connections"])
+    opts, args = getopt.getopt(
+        sys.argv[1:], "ht:p:c", ["help", "time=", "port=", "ignore-connections"]
+    )
     if len(opts) == 0:
         raise getopt.GetoptError("No input parameters!")
     for opt, arg in opts:
@@ -69,57 +73,78 @@ if missingConfiguration:
 
 
 def is_idle(last_activity):
-    last_activity = datetime.strptime(last_activity,"%Y-%m-%dT%H:%M:%S.%fz")
+    last_activity = datetime.strptime(last_activity, "%Y-%m-%dT%H:%M:%S.%fz")
     if (datetime.now() - last_activity).total_seconds() > time:
-        print('Notebook is idle. Last activity time = ', last_activity)
+        print("Jupyter is idle. Last activity time = ", last_activity)
         return True
     else:
-        print('Notebook is not idle. Last activity time = ', last_activity)
+        print("Jupyter is not idle. Last activity time = ", last_activity)
         return False
 
 
+def is_terminal_active():
+    response = requests.get(
+        f"https://localhost:{port}/api/terminals",
+        verify=False,
+    )
+    terminal_data = response.json()
+    return len(terminal_data) > 0
+
+
 def get_notebook_name():
-    log_path = '/opt/ml/metadata/resource-metadata.json'
-    with open(log_path, 'r') as logs:
+    log_path = "/opt/ml/metadata/resource-metadata.json"
+    with open(log_path, "r") as logs:
         _logs = json.load(logs)
-    return _logs['ResourceName']
+    return _logs["ResourceName"]
+
 
 # This is hitting Jupyter's sessions API: https://github.com/jupyter/jupyter/wiki/Jupyter-Notebook-Server-API#Sessions-API
-response = requests.get('https://localhost:'+port+'/api/sessions', verify=False)
+response = requests.get("https://localhost:" + port + "/api/sessions", verify=False)
 data = response.json()
 if len(data) > 0:
     for notebook in data:
         # Idleness is defined by Jupyter
         # https://github.com/jupyter/notebook/issues/4634
-        if notebook['kernel']['execution_state'] == 'idle':
+        if notebook["kernel"]["execution_state"] == "idle":
             if not ignore_connections:
-                if notebook['kernel']['connections'] == 0:
-                    if not is_idle(notebook['kernel']['last_activity']):
+                if notebook["kernel"]["connections"] == 0:
+                    if not is_idle(notebook["kernel"]["last_activity"]):
                         idle = False
                 else:
                     idle = False
-                    print('Notebook idle state set as %s because no kernel has been detected.' % idle)
+                    print(
+                        "Jupyter idle state set as %s because no kernel has been detected."
+                        % idle
+                    )
             else:
-                if not is_idle(notebook['kernel']['last_activity']):
+                if not is_idle(notebook["kernel"]["last_activity"]):
                     idle = False
-                    print('Notebook idle state set as %s since kernel connections are ignored.' % idle)
+                    print(
+                        "Jupyter idle state set as %s since kernel connections are ignored."
+                        % idle
+                    )
+        elif not is_terminal_active():
+            if not is_idle(notebook["kernel"]["last_activity"]):
+                idle = False
+                print(
+                    "Jupyter idle state set as %s since kernel connections are ignored."
+                    % idle
+                )
         else:
-            print('Notebook is not idle:', notebook['kernel']['execution_state'])
+            print("Jupyter is not idle:", notebook["kernel"]["execution_state"])
             idle = False
 else:
-    client = boto3.client('sagemaker')
+    client = boto3.client("sagemaker")
     uptime = client.describe_notebook_instance(
         NotebookInstanceName=get_notebook_name()
-    )['LastModifiedTime']
+    )["LastModifiedTime"]
     if not is_idle(uptime.strftime("%Y-%m-%dT%H:%M:%S.%fz")):
         idle = False
-        print('Notebook idle state set as %s since no sessions detected.' % idle)
+        print("Jupyter idle state set as %s since no sessions detected." % idle)
 
 if idle:
-    print('Closing idle notebook')
-    client = boto3.client('sagemaker')
-    client.stop_notebook_instance(
-        NotebookInstanceName=get_notebook_name()
-    )
+    print("Closing idle notebook")
+    client = boto3.client("sagemaker")
+    client.stop_notebook_instance(NotebookInstanceName=get_notebook_name())
 else:
-    print('Notebook not idle. Pass.')
+    print("Notebook not idle. Pass.")

--- a/scripts/auto-stop-idle/autostop.py
+++ b/scripts/auto-stop-idle/autostop.py
@@ -133,9 +133,10 @@ else:
 
 # Check terminals is idle or not
 response = requests.get(
-    f"https://localhost:{port}/api/terminals",
+    f"https://localhost:{port}//terminals",
     verify=False,
 )
+print(response)
 idle = idle or is_terminal_state(data)
 
 if idle:

--- a/scripts/auto-stop-idle/autostop.py
+++ b/scripts/auto-stop-idle/autostop.py
@@ -83,8 +83,9 @@ def is_idle(last_activity):
 
 
 def is_terminal_state(response):
-    for notebook in response:
-        if is_idle(notebook["last_activity"]):
+    for terminal in response:
+        print(terminal)
+        if is_idle(terminal["last_activity"]):
             return True
     return False
 

--- a/scripts/auto-stop-idle/autostop.py
+++ b/scripts/auto-stop-idle/autostop.py
@@ -133,13 +133,13 @@ else:
         print(f"Notebook idle state set as {idle} since no sessions detected.")
 
 # Check terminals is idle or not
-response = requests.get(
+terminal_response = requests.get(
     f"https://localhost:{port}/api/terminals",
     verify=False,
 )
-data = response.json()
+terminal_data = terminal_response.json()
 
-terminal_idle = is_terminal_state(data) if data else True
+terminal_idle = is_terminal_state(terminal_data) if terminal_data else True
 
 idle = idle and terminal_idle
 

--- a/scripts/auto-stop-idle/autostop.py
+++ b/scripts/auto-stop-idle/autostop.py
@@ -138,7 +138,10 @@ response = requests.get(
     verify=False,
 )
 data = response.json()
-idle = idle and is_terminal_state(data)
+
+terminal_idle = is_terminal_state(data) if data else True
+
+idle = idle and terminal_idle
 
 if idle:
     print("Closing idle notebook")


### PR DESCRIPTION
**Issue #, if available:**
Issue: https://github.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples/issues/90

**Description of changes:**
The current sample lifecycle configuration only checks for notebook sessions. I have updated it to also monitor terminal sessions. This enhancement is vital as the instance will not stop if there are any non-idle notebook sessions.

**Testing Done**

- [x] Notebook Instance created successfully with the Lifecycle Configuration
- [x] Notebook Instance stopped and started successfully
- [NA] Documentation in the script around any network access requirements
- [NA] Documentation in the script around any IAM permission requirements
- [x] CLI commands used to validate functionality on the instance
- [NA] New script link and description added to README.md


Idle time is set to 10 minutes.
```
*/5 * * * * /home/ec2-user/anaconda3/bin/python3 /tmp/autostop.py --time 600 --ignore-connections>> /var/log/jupyter.log
```

Logs showing kernel activity:

```
  | 2023-12-12T11:52:04.602+09:00 | [I 2023-12-12 02:51:59.963 ServerApp] New terminal with automatic name: 1
  | 2023-12-12T11:52:20.603+09:00 | [I 2023-12-12 02:52:15.685 ServerApp] New terminal with automatic name: 2
  | 2023-12-12T11:55:02.391+09:00 | Kernel is not idle. Last activity time = 2023-12-12 02:51:43.955000
  | 2023-12-12T11:55:02.391+09:00 | Notebook idle state set as False since no sessions detected.
  | 2023-12-12T11:55:02.391+09:00 | {'name': '1', 'last_activity': '2023-12-12T02:53:44.396492Z'}
  | 2023-12-12T11:55:02.391+09:00 | Kernel is not idle. Last activity time = 2023-12-12 02:53:44.396492
  | 2023-12-12T11:55:02.391+09:00 | {'name': '2', 'last_activity': '2023-12-12T02:53:00.323036Z'}
  | 2023-12-12T11:55:02.391+09:00 | Kernel is not idle. Last activity time = 2023-12-12 02:53:00.323036
  | 2023-12-12T11:55:06.602+09:00 | Kernel not idle. Pass.
  | 2023-12-12T12:00:01.980+09:00 | Kernel is not idle. Last activity time = 2023-12-12 02:51:43.955000
  | 2023-12-12T12:00:01.980+09:00 | Notebook idle state set as False since no sessions detected.
  | 2023-12-12T12:00:01.980+09:00 | {'name': '1', 'last_activity': '2023-12-12T02:53:44.396492Z'}
  | 2023-12-12T12:00:01.980+09:00 | Kernel is not idle. Last activity time = 2023-12-12 02:53:44.396492
  | 2023-12-12T12:00:01.980+09:00 | {'name': '2', 'last_activity': '2023-12-12T02:55:38.896191Z'}
  | 2023-12-12T12:00:01.980+09:00 | Kernel is not idle. Last activity time = 2023-12-12 02:55:38.896191
  | 2023-12-12T12:00:06.602+09:00 | Kernel not idle. Pass.
  | 2023-12-12T12:05:02.021+09:00 | Kernel is idle. Last activity time = 2023-12-12 02:51:43.955000
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
