### PR TITLE
Enable fips openssl provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Lifecycle Configurations provide a mechanism to customize Notebook Instances via
 * [auto-stop-idle](scripts/auto-stop-idle) - This script stops a SageMaker notebook once it's idle for more than 1 hour. (default time)
 * [connect-emr-cluster](scripts/connect-emr-cluster) - This script connects an EMR cluster to the Notebook Instance using SparkMagic.
 * [disable-uninstall-ssm-agent](scripts/disable-uninstall-ssm-agent) - This script disables and uninstalls the SSM Agent at startup.
+* [enable-fips-openssl-provider](scripts/enable-fips-openssl-provider) - This script enables the OpenSSL FIPS provider in each conda environment.
 * [execute-notebook-on-startup](scripts/execute-notebook-on-startup) - This script executes a Notebook file on the instance during startup.
 * [export-to-pdf-enable](scripts/export-to-pdf-enable) - This script enables Jupyter to export a notebook directly to PDF.
 * [install-conda-package-all-environments](scripts/install-conda-package-all-environments) - This script installs a single conda package in all SageMaker conda environments, apart from the JupyterSystemEnv which is a system environment reserved for Jupyter.

--- a/scripts/enable-fips-openssl-provider/on-start.sh
+++ b/scripts/enable-fips-openssl-provider/on-start.sh
@@ -14,6 +14,7 @@ for ENV in /home/ec2-user/anaconda3/envs/*; do
    # Check if the openssl.cnf file exists
    if [[ -f "$openssl_cnf_path" ]]; then
        # Use sed to make the required modifications
+       # openssl.cnf modifications are described here: https://github.com/openssl/openssl/blob/master/README-FIPS.md
        sed -i.bak 's|^# \.include fipsmodule\.cnf|\.include /home/ec2-user/anaconda3/envs/'"$ENV_NAME"'/ssl/fipsmodule.cnf|' "$openssl_cnf_path"
        sed -i.bak 's|^# fips = fips_sect|fips = fips_sect|' "$openssl_cnf_path"
        sed -i.bak 's|^# activate = 1|activate = 1|' "$openssl_cnf_path"

--- a/scripts/enable-fips-openssl-provider/on-start.sh
+++ b/scripts/enable-fips-openssl-provider/on-start.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Iterate through each conda environment
+for ENV in /home/ec2-user/anaconda3/envs/*; do
+   ENV_NAME=$(basename $ENV)
+   # Skip any non-directory and JupyterSystemEnv
+   if [[ ! -d "$ENV" || $ENV_NAME == "JupyterSystemEnv" ]]; then
+       continue
+   fi
+
+   # Construct the path to the openssl.cnf file within the environment
+   openssl_cnf_path="$ENV/ssl/openssl.cnf"
+
+   # Check if the openssl.cnf file exists
+   if [[ -f "$openssl_cnf_path" ]]; then
+       # Use sed to make the required modifications
+       sed -i.bak 's|^# \.include fipsmodule\.cnf|\.include /home/ec2-user/anaconda3/envs/'"$ENV_NAME"'/ssl/fipsmodule.cnf|' "$openssl_cnf_path"
+       sed -i.bak 's|^# fips = fips_sect|fips = fips_sect|' "$openssl_cnf_path"
+       sed -i.bak 's|^# activate = 1|activate = 1|' "$openssl_cnf_path"
+       sed -i.bak '/providers = provider_sect/a\
+alg_section = algorithm_sect' "$openssl_cnf_path"
+       sed -i.bak '/activate = 1/a\
+[algorithm_sect]\
+default_properties = fips=yes' "$openssl_cnf_path"
+
+       echo "Updated openssl.cnf at $openssl_cnf_path"
+   else
+       echo "Warning: openssl.cnf file not found at $openssl_cnf_path"
+   fi
+done

--- a/scripts/notebook-history-s3/on-start.sh
+++ b/scripts/notebook-history-s3/on-start.sh
@@ -17,4 +17,4 @@ echo "Fetching the log history script"
 wget https://raw.githubusercontent.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples/master/scripts/notebook-history-s3/notebook-history-s3.py
 echo "Starting the SageMaker logging script in cron"
 
-(crontab -l 2>/dev/null; echo "0 * * * * /usr/bin/python3 $PWD/notebook_history_s3.py") | crontab -
+(crontab -l 2>/dev/null; echo "0 * * * * /usr/bin/python3 $PWD/notebook-history-s3.py") | crontab -


### PR DESCRIPTION
**Issue #, if available:**
1. None for the enabling openssl FIPS provider.
2. This PR also fixes the issue https://github.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples/issues/63

**Description of changes:**
1. https://www.openssl.org/docs/manmaster/man7/fips_module.html for OpenSSL FIPS provider instructions

**Testing Done**

- [X] Notebook Instance created successfully with the Lifecycle Configuration
- [X] Notebook Instance stopped and started successfully
- [X] Documentation in the script around any network access requirements
- [X] Documentation in the script around any IAM permission requirements
- [X] CLI commands used to validate functionality on the instance
- [X] New script link and description added to README.md

```
# Provide your commands here
touch /home/ec2-user/testfile.txt
source activate python3
openssl md5 /home/ec2-user/testfile.txt
```

An error would be produced:
```
Error setting digest
4077B033057F0000:error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:crypto/evp/evp_fetch.c:341:Global default library context, Algorithm (MD5 : 100), Properties ()
4077B033057F0000:error:03000086:digital envelope routines:evp_md_init_internal:initialization error:crypto/evp/digest.c:272:
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
