### PR TITLE
Added conda-forge and latest version of miniconda to be able to use Python 3.12

### DIFF
--- a/scripts/persistent-conda-ebs/on-create.sh
+++ b/scripts/persistent-conda-ebs/on-create.sh
@@ -28,8 +28,11 @@ source "$WORKING_DIR/miniconda/bin/activate"
 KERNEL_NAME="custom_python"
 PYTHON="3.6"
 
+echo "INFO: Creating new conda environment with name $KERNEL_NAME and Python version $PYTHON"
+conda config --prepend channels conda-forge
 conda create --yes --name "$KERNEL_NAME" python="$PYTHON"
 conda activate "$KERNEL_NAME"
+echo "INFO: Python version: `python --version`"
 
 pip install --quiet ipykernel
 

--- a/scripts/persistent-conda-ebs/on-create.sh
+++ b/scripts/persistent-conda-ebs/on-create.sh
@@ -18,7 +18,7 @@ unset SUDO_UID
 # Install a separate conda installation via Miniconda
 WORKING_DIR=/home/ec2-user/SageMaker/custom-miniconda
 mkdir -p "$WORKING_DIR"
-wget https://repo.anaconda.com/miniconda/Miniconda3-4.6.14-Linux-x86_64.sh -O "$WORKING_DIR/miniconda.sh"
+wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O "$WORKING_DIR/miniconda.sh"
 bash "$WORKING_DIR/miniconda.sh" -b -u -p "$WORKING_DIR/miniconda" 
 rm -rf "$WORKING_DIR/miniconda.sh"
 


### PR DESCRIPTION
…Python 3.12 works

**Issue #, if available:**

**Description of changes:**

**Testing Done**

- [x] Notebook Instance created successfully with the Lifecycle Configuration
- [x] Notebook Instance stopped and started successfully
- [ ] Documentation in the script around any network access requirements
- [ ] Documentation in the script around any IAM permission requirements
- [ ] CLI commands used to validate functionality on the instance
- [ ] New script link and description added to README.md

```
# Provide your commands here
I had issues when I was trying to install Python version 3.12, because it coulden't be found in the given channels. This fixed it for me.
```





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
